### PR TITLE
pipeline script + compatibility with kilosort2

### DIFF
--- a/Dependencies/DataPreparation/ConvertTemplatesAfterPhy.m
+++ b/Dependencies/DataPreparation/ConvertTemplatesAfterPhy.m
@@ -49,7 +49,7 @@ sp.tempsUnW = tempsUnW(takeclus,:,:);
 sp.templateDuration = templateDuration(takeclus);
 sp.waveforms = waveforms(takeclus,:);
 if any(emptyclus)
-disp(['Found ' num2str(length(emptyclus)) ' empty clusters, phy error? Removing from clusinfo'])
+disp(['Found ' num2str(length(emptyclus)) ' empty clusters. Removing from clusinfo'])
 end
 
 %% Remove the empty clusters

--- a/Dependencies/DataPreparation/PrepareClusInfo.m
+++ b/Dependencies/DataPreparation/PrepareClusInfo.m
@@ -1,5 +1,6 @@
-function Params = PrepareClusInfo(KiloSortPaths,Params,RawDataPaths)
+function Params = PrepareClusInfo(KiloSortPaths, Params, RawDataPaths)
 % Prepares cluster information for subsequent analysis
+
 %% Inputs:
 % KiloSortPaths = List of directories pointing at kilosort output (same format as what you get when
 % calling 'dir') for all sessions you want to analyze as one session (e.g.
@@ -27,7 +28,6 @@ function Params = PrepareClusInfo(KiloSortPaths,Params,RawDataPaths)
 % optionally Quality and Matches (oversplits/matches across recordings) are identified
 % Sp: Struct with spike information for all recordings
 
-
 %% Check inputs
 if ~iscell(KiloSortPaths) %isstruct(KiloSortPaths) || isfield(KiloSortPaths(1),'name') || isfield(KiloSortPaths(1),'folder')
     error('This is not a cell... give correct input please')
@@ -35,26 +35,30 @@ end
 
 
 try
-    if nargin<2
+    if nargin < 2
         disp('No params given. Use default - although this is not advised...')
-        Params.loadPCs=1;
+        Params.loadPCs = 1;
         Params.RunPyKSChronicStitched = 1;
         Params.DecompressLocal = 1; %if 1, uncompress data first if it's currently compressed
         Params.RedoQM = 0; %if 1, redo quality metrics if it already exists
         Params.RunQualityMetrics = 1; % If 1, Run the quality metrics
-        Params.InspectQualityMetrics =0; % Inspect the quality metrics/data set using the GUI
+        Params.InspectQualityMetrics = 0; % Inspect the quality metrics/data set using the GUI
         Params.UnitMatch = 1; % Matching chronic recording using QM instead of using pyks chronic output
         Params.RedoUnitMatch = 0; % Redo unitmatch
         Params.SaveDir = KiloSortPaths(1); % Directory to save QM and UnitMatch results
         Params.tmpdatafolder = KiloSortPaths(1); %
         Params.binsz = 0.01; % Binsize in time (s) for the cross-correlation fingerprint. We recommend ~2-10ms time windows
         Params.saveSp = 0;
+        Params.extractSync = 0;
+        Params.deNoise = 1;
+        Params.nSavedChans = 385;
+        Params.nSyncChans = 1;
     end
     if Params.RunQualityMetrics
-        Params.loadPCs=1; %If you want to run QM you need this
+        Params.loadPCs = 1; %If you want to run QM you need this
     end
 
-    if nargin<3
+    if nargin < 3
         disp('Finding raw ephys data using the params.py file from (py)kilosort output')
         UseParamsKS = 1;
     else
@@ -66,21 +70,22 @@ catch ME
 end
 
 %% Initialize everything
-channelmap=[];
+channelmap = [];
 channelpos = [];
 
-AllKiloSortPaths = cell(1,0);
-AllChannelPos = cell(1,0);
-countid=1;
+AllKiloSortPaths = cell(1, 0);
+AllChannelPos = cell(1, 0);
+countid = 1;
 % figure;
 cols = jet(length(KiloSortPaths));
-for subsesid=1:length(KiloSortPaths)
-    if isempty(dir(fullfile(KiloSortPaths{subsesid},'*.npy')))
+for subsesid = 1:length(KiloSortPaths)
+    if isempty(dir(fullfile(KiloSortPaths{subsesid}, '*.npy')))
         continue
     end
+
     %% initialize for new round
     Good_ID = [];
-    Shank=[];
+    Shank = [];
     ProbeAll = [];
     recsesAll = [];
     channel = [];
@@ -89,8 +94,8 @@ for subsesid=1:length(KiloSortPaths)
     AllUniqueTemplates = [];
     cluster_id = [];
     recses = [];
-    if any(strfind(KiloSortPaths{subsesid},'Probe'))
-        probeid = str2num(KiloSortPaths{subsesid}(strfind(KiloSortPaths{subsesid},'Probe')+5));
+    if any(strfind(KiloSortPaths{subsesid}, 'Probe'))
+        probeid = str2num(KiloSortPaths{subsesid}(strfind(KiloSortPaths{subsesid}, 'Probe') + 5));
     else
         disp('Probe ID unknown')
         probeid = 0;
@@ -100,40 +105,40 @@ for subsesid=1:length(KiloSortPaths)
     if Params.RunPyKSChronicStitched %CALL THIS STITCHED --> Only works when using RunPyKS2_FromMatlab as well from this toolbox
         if UseParamsKS
             try
-                spikeStruct = loadParamsPy(fullfile(KiloSortPaths{subsesid},'params.py'));
+                spikeStruct = loadParamsPy(fullfile(KiloSortPaths{subsesid}, 'params.py'));
                 rawD = spikeStruct.dat_path;
-                rawD = strsplit(rawD,',');
-                for rid=1:length(rawD)
-                    rawD{rid} = rawD{rid}(strfind(rawD{rid},'"')+1:end);
-                    rawD{rid} = rawD{rid}(1:strfind(rawD{rid},'"')-1);
+                rawD = strsplit(rawD, ',');
+                for rid = 1:length(rawD)
+                    rawD{rid} = rawD{rid}(strfind(rawD{rid}, '"') + 1:end);
+                    rawD{rid} = rawD{rid}(1:strfind(rawD{rid}, '"') - 1);
                     rawD{rid} = dir(rawD{rid});
                     if isempty(rawD{rid})
-                        rawD{rid} = dir(strrep(rawD{rid},'bin','cbin'));
+                        rawD{rid} = dir(strrep(rawD{rid}, 'bin', 'cbin'));
                     end
                 end
-                rawD = cat(2,rawD{:});
+                rawD = cat(2, rawD{:});
             catch
-                sessionsIncluded = dir(fullfile(KiloSortPaths{subsesid},'SessionsIncluded.mat'));
-                sessionsIncluded = load(fullfile(sessionsIncluded.folder,sessionsIncluded.name));
-                rawD = arrayfun(@(X) dir(sessionsIncluded.ThesePaths{X}),1:length(sessionsIncluded.ThesePaths),'UniformOutput',0);
-                rawD = cat(2,rawD{:});
+                sessionsIncluded = dir(fullfile(KiloSortPaths{subsesid}, 'SessionsIncluded.mat'));
+                sessionsIncluded = load(fullfile(sessionsIncluded.folder, sessionsIncluded.name));
+                rawD = arrayfun(@(X) dir(sessionsIncluded.ThesePaths{X}), 1:length(sessionsIncluded.ThesePaths), 'UniformOutput', 0);
+                rawD = cat(2, rawD{:});
             end
         else
-            rawD = dir(fullfile(RawDataPaths(subsesid).folder,RawDataPaths(subsesid).name));
+            rawD = dir(fullfile(RawDataPaths(subsesid).folder, RawDataPaths(subsesid).name));
         end
 
         RawDataPaths = rawD;
-        AllKiloSortPaths = cat(2,AllKiloSortPaths{:},repmat(KiloSortPaths(subsesid),1,length(rawD)));
+        AllKiloSortPaths = cat(2, AllKiloSortPaths{:}, repmat(KiloSortPaths(subsesid), 1, length(rawD)));
     else
         if UseParamsKS
-            spikeStruct = loadParamsPy(fullfile(KiloSortPaths{subsesid},'params.py'));
+            spikeStruct = loadParamsPy(fullfile(KiloSortPaths{subsesid}, 'params.py'));
             rawD = spikeStruct.dat_path;
-            rawD = rawD(strfind(rawD,'"')+1:end);
-            rawD = rawD(1:strfind(rawD,'"')-1);
+            rawD = rawD(strfind(rawD, '"')+1:end);
+            rawD = rawD(1:strfind(rawD, '"')-1);
             tmpdr = rawD;
             rawD = dir(rawD);
             if isempty(rawD)
-                rawD = dir(strrep(tmpdr,'bin','cbin'));
+                rawD = dir(strrep(tmpdr, 'bin', 'cbin'));
             end
 
 
@@ -145,36 +150,50 @@ for subsesid=1:length(KiloSortPaths)
                 keyboard
             end
         else
-            rawD = dir(fullfile(RawDataPaths(subsesid).folder,RawDataPaths(subsesid).name));
+            if isstruct(RawDataPaths)
+                rawD = dir(fullfile(RawDataPaths(subsesid).folder, RawDataPaths(subsesid).name));
+
+            else
+                rawD = dir(fullfile(RawDataPaths{subsesid}));
+            end
+
         end
-        AllKiloSortPaths = {AllKiloSortPaths{:} KiloSortPaths{subsesid}};
+        AllKiloSortPaths = {AllKiloSortPaths{:}, KiloSortPaths{subsesid}};
     end
     DecompressionFlag = 0;
 
     %% Channel data
-    myClusFile = dir(fullfile(KiloSortPaths{subsesid},'channel_map.npy'));
-    channelmaptmp = readNPY(fullfile(myClusFile(1).folder,myClusFile(1).name));
+    myClusFile = dir(fullfile(KiloSortPaths{subsesid}, 'channel_map.npy'));
+    channelmaptmp = readNPY(fullfile(myClusFile(1).folder, myClusFile(1).name));
 
-    myClusFile = dir(fullfile(KiloSortPaths{subsesid},'channel_positions.npy'));
-    channelpostmp = readNPY(fullfile(myClusFile(1).folder,myClusFile(1).name));
-    if length(channelmaptmp)<length(channelpostmp)
-        channelmaptmp(end+1:length(channelpostmp))=length(channelmaptmp):length(channelpostmp)-1;
+    myClusFile = dir(fullfile(KiloSortPaths{subsesid}, 'channel_positions.npy'));
+    channelpostmp = readNPY(fullfile(myClusFile(1).folder, myClusFile(1).name));
+    if length(channelmaptmp) < length(channelpostmp)
+        channelmaptmp(end+1:length(channelpostmp)) = length(channelmaptmp):length(channelpostmp) - 1;
+    end
+    if length(channelmaptmp) < (Params.nSavedChans - Params.nSyncChans) %for Kilosort2, "dead" sites are removed. Add them back here 
+        channelmaptmp_full = [0:(Params.nSavedChans - Params.nSyncChans)]';
+        missing_sites = ismember(channelmaptmp_full, channelmaptmp);
+        depth_step = median(diff(channelpostmp(:,2)));
+        x_arrangement = unique(channelpostmp(:,1));
+        channel_map_full  = nan(size(channelmaptmp_full,1),2);
+        channel_map_full(missing_sites,:) = channelpostmp ;
     end
 
     %% Is it correct channelpos though...? Check using raw data
-    channelpostmpconv = ChannelIMROConversion(rawD(1).folder,0); % For conversion when not automatically done
+    channelpostmpconv = ChannelIMROConversion(rawD(1).folder, 0); % For conversion when not automatically done
     AllChannelPos{countid} = channelpostmpconv;
 
     %% Load existing?
-    if exist(fullfile(KiloSortPaths{subsesid},'PreparedData.mat')) && ~Params.RedoQM && ~Params.ReLoadAlways
+    if exist(fullfile(KiloSortPaths{subsesid}, 'PreparedData.mat')) && ~Params.RedoQM && ~Params.ReLoadAlways
         % Check if parameters are the same, of not we have to redo it
         % anyway
-        tmpparam = matfile(fullfile(KiloSortPaths{subsesid},'PreparedData.mat'));
+        tmpparam = matfile(fullfile(KiloSortPaths{subsesid}, 'PreparedData.mat'));
         tmpparam = tmpparam.Params;
 
-        if tmpparam.RunQualityMetrics == Params.RunQualityMetrics && tmpparam.RunPyKSChronicStitched==Params.RunPyKSChronicStitched &&...
+        if tmpparam.RunQualityMetrics == Params.RunQualityMetrics && tmpparam.RunPyKSChronicStitched == Params.RunPyKSChronicStitched && ...
                 tmpparam.separateIMRO == Params.separateIMRO
-            disp(['Found existing data in ' KiloSortPaths{subsesid} ', Using this...'])
+            disp(['Found existing data in ', KiloSortPaths{subsesid}, ', Using this...'])
             %         load(fullfile(Params.SaveDir,'PreparedData.mat'))
 
             % Use UnitMatch Output if available
@@ -183,135 +202,144 @@ for subsesid=1:length(KiloSortPaths)
             %             sp.clu = sp.UniqClu; %Temporary replace for rest of code
             %             clusinfo.cluster_id = clusinfo.UniqueID;
             %         end
-            countid=countid+1;
+            countid = countid + 1;
             continue
         end
     end
 
     %% Load histology if available
-    tmphisto = dir(fullfile(KiloSortPaths{subsesid},'HistoEphysAlignment.mat'));
+    tmphisto = dir(fullfile(KiloSortPaths{subsesid}, 'HistoEphysAlignment.mat'));
     clear Depth2AreaPerUnit
     if ~isempty(tmphisto)
-        histodat = load(fullfile(tmphisto.folder,tmphisto.name));
+        histodat = load(fullfile(tmphisto.folder, tmphisto.name));
         Depth2AreaPerUnit = histodat.Depth2AreaPerUnit;
     end
 
     %% Load Spike Data
-    sp = loadKSdir(fullfile(KiloSortPaths{subsesid}),Params); % Load Spikes with PCs
-    [sp.spikeAmps, sp.spikeDepths, sp.templateDepths, sp.templateXpos, sp.tempAmps, sp.tempsUnW, sp.templateDuration, sp.waveforms] = templatePositionsAmplitudes(sp.temps, sp.winv, sp.ycoords, sp.xcoords, sp.spikeTemplates, sp.tempScalingAmps); %from the spikes toolbox
-
+    sp = loadKSdir(fullfile(KiloSortPaths{subsesid}), Params); % Load Spikes with PCs
+    [sp.spikeAmps, sp.spikeDepths, sp.templateDepths, sp.templateXpos, sp.tempAmps, sp.tempsUnW, sp.templateDuration, sp.waveforms] = ...
+        templatePositionsAmplitudes(sp.temps, sp.winv, sp.ycoords, sp.xcoords, sp.spikeTemplates, sp.tempScalingAmps); %from the spikes toolbox
+    templateWaveforms = sp.temps;
     %% Remove noise; spikes across all channels'
-    sp = RemoveNoiseAmplitudeBased(sp);
+    if Params.deNoise == 1
+        sp = RemoveNoiseAmplitudeBased(sp);
+    end
 
     %% Bombcell parameters
     % clear paramBC
-    paramBC = bc_qualityParamValuesForUnitMatch(dir(strrep(fullfile(rawD(1).folder,rawD(1).name),'cbin','meta')),fullfile(Params.tmpdatafolder,strrep(rawD(1).name,'cbin','bin')));
+    paramBC = bc_qualityParamValuesForUnitMatch(dir(strrep(fullfile(rawD(1).folder, rawD(1).name), 'cbin', 'meta')), fullfile(Params.tmpdatafolder, strrep(rawD(1).name, 'cbin', 'bin')));
 
     %% Load Cluster Info
-    myClusFile = dir(fullfile(KiloSortPaths{subsesid},'cluster_info.tsv')); % If you did phy (manual curation) we will find this one... We can trust you, right?
+    myClusFile = dir(fullfile(KiloSortPaths{subsesid}, 'cluster_info.tsv')); % If you did phy (manual curation) we will find this one... We can trust you, right?
     if isempty(myClusFile)
         disp('This data is not curated with phy! Hopefully you''re using automated quality metrics to find good units!')
-        curratedflag=0;
+        curratedflag = 0;
         myClusFile = dir(fullfile(KiloSortPaths{subsesid},'cluster_group.tsv'));
-        clusinfo = tdfread(fullfile(myClusFile(1).folder,myClusFile(1).name));
+        if isempty(myClusFile)
+            clusinfo = tdfread(fullfile(KiloSortPaths{subsesid}, 'cluster_KSLabel.tsv'));
+        else
+            clusinfo = tdfread(fullfile(myClusFile(1).folder, myClusFile(1).name));
+        end
+        
         % Convert sp data to correct cluster according to phy (clu and
         % template are not necessarily the same after phy)
         [clusinfo,sp] = ConvertTemplatesAfterPhy(clusinfo,sp);
 
+        %clusidtmp = clusinfo.cluster_id;
+        clusinfo.cluster_id = unique(sp.spikeTemplates);
         clusidtmp = clusinfo.cluster_id;
-        cluster_id = cat(1,cluster_id,clusinfo.cluster_id);
         tmpLabel = char(length(clusinfo.cluster_id));
-        KSLabelfile = tdfread(fullfile(KiloSortPaths{subsesid},'cluster_KSLabel.tsv'));
-        tmpLabel(ismember(clusinfo.cluster_id,KSLabelfile.cluster_id)) = KSLabelfile.KSLabel(ismember(KSLabelfile.cluster_id,clusinfo.cluster_id));
-        Label = [Label,tmpLabel];
-        totSpkNum = histc(sp.clu,sp.cids);
-        Good_IDtmp = ismember(tmpLabel,'g') & totSpkNum'>paramBC.minNumSpikes; %Identify good clusters
+        KSLabelfile = tdfread(fullfile(KiloSortPaths{subsesid}, 'cluster_KSLabel.tsv'));
+        tmpLabel(ismember(clusinfo.cluster_id, KSLabelfile.cluster_id)) = KSLabelfile.KSLabel(ismember(KSLabelfile.cluster_id, clusinfo.cluster_id));
+        Label = [Label, tmpLabel];
+        totSpkNum = histc(sp.clu, sp.cids);
+        Good_IDtmp = ismember(tmpLabel, 'g') & totSpkNum' > paramBC.minNumSpikes; %Identify good clusters
 
         % Find depth and channel
-        depthtmp = nan(length(clusinfo.cluster_id),1);
-        xtmp = nan(length(clusinfo.cluster_id),1);
-        channeltmp = nan(length(clusinfo.cluster_id),1);
-        for clusid=1:length(depthtmp)
+        depthtmp = nan(length(clusinfo.cluster_id), 1);
+        xtmp = nan(length(clusinfo.cluster_id), 1);
+        channeltmp = nan(length(clusinfo.cluster_id), 1);
+        for clusid = 1:length(depthtmp)
             % Depth according to PyKS2 output
-            depthtmp(clusid)=round(sp.templateDepths(clusid));%round(nanmean(sp.spikeDepths(find(sp.clu==clusid-1))));
-            xtmp(clusid)=sp.templateXpos(clusid);
-            [~,minidx] = min(cell2mat(arrayfun(@(X) pdist(cat(1,channelpostmp(X,:),[xtmp(clusid),depthtmp(clusid)]),'euclidean'),1:size(channelpostmp,1),'UniformOutput',0)));
+            depthtmp(clusid) = round(sp.templateDepths(clusid)); %round(nanmean(sp.spikeDepths(find(sp.clu==clusid-1))));
+            xtmp(clusid) = sp.templateXpos(clusid);
+            [~, minidx] = min(cell2mat(arrayfun(@(X) pdist(cat(1, channelpostmp(X, :), [xtmp(clusid), depthtmp(clusid)]), 'euclidean'), 1:size(channelpostmp, 1), 'UniformOutput', 0)));
             try
                 channeltmp(clusid) = channelmaptmp(minidx);
-                depthtmp(clusid) = channelpostmpconv(minidx,2);
-                xtmp(clusid) = channelpostmpconv(minidx,1);
+                depthtmp(clusid) = channelpostmpconv(minidx, 2);
+                xtmp(clusid) = channelpostmpconv(minidx, 1);
             catch
-                channeltmp(clusid)=channelmaptmp(minidx-1);
-                depthtmp(clusid) = channelpostmpconv(minidx-1,2);
-                xtmp(clusid) = channelpostmpconv(minidx-1,1);
+                channeltmp(clusid) = channelmaptmp(minidx-1);
+                depthtmp(clusid) = channelpostmpconv(minidx-1, 2);
+                xtmp(clusid) = channelpostmpconv(minidx-1, 1);
             end
-            sp.spikeDepths(ismember(sp.clu,clusidtmp(clusid))) = depthtmp(clusid);
+            sp.spikeDepths(ismember(sp.clu, clusidtmp(clusid))) = depthtmp(clusid);
 
         end
-        depth = cat(1,depth, depthtmp);
-        channel = cat(1,channel,channeltmp);
+        depth = cat(1, depth, depthtmp);
+        channel = cat(1, channel, channeltmp);
 
     else
         disp('You did manual curation. You champion. If you have not enough time, maybe consider some automated algorithm...')
         CurationDone = 1;
-        save(fullfile(KiloSortPaths{subsesid},'CuratedResults.mat'),'CurationDone')
-        clusinfo = tdfread(fullfile(myClusFile(1).folder,myClusFile(1).name));
+        save(fullfile(KiloSortPaths{subsesid}, 'CuratedResults.mat'), 'CurationDone')
+        clusinfo = tdfread(fullfile(myClusFile(1).folder, myClusFile(1).name));
         % Convert sp data to correct cluster according to phy (clu and
         % template are not necessarily the same after phy)
-        [clusinfo,sp] = ConvertTemplatesAfterPhy(clusinfo,sp);
+        [clusinfo, sp] = ConvertTemplatesAfterPhy(clusinfo, sp);
 
-        curratedflag=1;
-        if isfield(clusinfo,'id')
+        curratedflag = 1;
+        if isfield(clusinfo, 'id')
             clusidtmp = clusinfo.id;
-            cluster_id = [cluster_id,clusinfo.id];
-        elseif isfield(clusinfo,'cluster_id')
+            cluster_id = [cluster_id, clusinfo.id];
+        elseif isfield(clusinfo, 'cluster_id')
             clusidtmp = clusinfo.cluster_id;
 
-            cluster_id=[cluster_id,clusinfo.cluster_id];
+            cluster_id = [cluster_id, clusinfo.cluster_id];
         else
             keyboard
             disp('Someone thought it was nice to change the name again...')
         end
         KSLabel = clusinfo.KSLabel;
-        Label = [Label,clusinfo.group]; % You want the group, not the KSLABEL!
+        Label = [Label, clusinfo.group]; % You want the group, not the KSLABEL!
         % Find depth and channel
-        depthtmp = nan(length(clusidtmp),1);
-        xtmp = nan(length(clusidtmp),1);
-        channeltmp = nan(length(clusidtmp),1);
-        for clusid=1:length(depthtmp)
+        depthtmp = nan(length(clusidtmp), 1);
+        xtmp = nan(length(clusidtmp), 1);
+        channeltmp = nan(length(clusidtmp), 1);
+        for clusid = 1:length(depthtmp)
             % Depth according to PyKS2 output
-            depthtmp(clusid)=round(sp.templateDepths(clusid));%round(nanmean(sp.spikeDepths(find(sp.clu==clusid-1))));
-            xtmp(clusid)=sp.templateXpos(clusid);
-            [~,minidx] = min(cell2mat(arrayfun(@(X) pdist(cat(1,channelpostmp(X,:),[xtmp(clusid),depthtmp(clusid)]),'euclidean'),1:size(channelpostmp,1),'UniformOutput',0)));
+            depthtmp(clusid) = round(sp.templateDepths(clusid)); %round(nanmean(sp.spikeDepths(find(sp.clu==clusid-1))));
+            xtmp(clusid) = sp.templateXpos(clusid);
+            [~, minidx] = min(cell2mat(arrayfun(@(X) pdist(cat(1, channelpostmp(X, :), [xtmp(clusid), depthtmp(clusid)]), 'euclidean'), 1:size(channelpostmp, 1), 'UniformOutput', 0)));
             try
                 channeltmp(clusid) = channelmaptmp(minidx);
-                depthtmp(clusid) = channelpostmpconv(minidx,2);
-                xtmp(clusid) = channelpostmpconv(minidx,1);
+                depthtmp(clusid) = channelpostmpconv(minidx, 2);
+                xtmp(clusid) = channelpostmpconv(minidx, 1);
             catch
-                channeltmp(clusid)=channelmaptmp(minidx-1);
-                depthtmp(clusid) = channelpostmpconv(minidx-1,2);
-                xtmp(clusid) = channelpostmpconv(minidx-1,1);
+                channeltmp(clusid) = channelmaptmp(minidx-1);
+                depthtmp(clusid) = channelpostmpconv(minidx-1, 2);
+                xtmp(clusid) = channelpostmpconv(minidx-1, 1);
             end
-            sp.spikeDepths(ismember(sp.clu,clusidtmp(clusid))) = depthtmp(clusid);
+            sp.spikeDepths(ismember(sp.clu, clusidtmp(clusid))) = depthtmp(clusid);
 
         end
 
-        depth = [depth,depthtmp];
+        depth = [depth, depthtmp];
 
-        channel = [channel,clusinfo.ch];
-        Good_IDtmp = ismember(cellstr(clusinfo.group),'good');
+        channel = [channel, clusinfo.ch];
+        Good_IDtmp = ismember(cellstr(clusinfo.group), 'good');
         channeltmp = clusinfo.ch;
     end
     channelpostmp = channelpostmpconv;
-    ypostmp = channelpostmp(:,2);
-    xpostmp = channelpostmp(:,1);
-    xposopt = (floor(xpostmp./250));% Assuming no new shank if not at least 100 micron apart
+    ypostmp = channelpostmp(:, 2);
+    xpostmp = channelpostmp(:, 1);
+    xposopt = (floor(xpostmp./250)); % Assuming no new shank if not at least 100 micron apart
     Shanktmp = floor(xpostmp(channeltmp+1)./250);
 
     %     [~,minid] = arrayfun(@(X) (abs(floor(xpostmp(X)./250)-xposopt)),channeltmp+1,'UniformOutput',0);
-    Shank = cat(1,Shank,Shanktmp);
+    Shank = cat(1, Shank, Shanktmp);
 
-    recses = cat(1, recses, repmat(countid,length(channeltmp),1));
+    recses = cat(1, recses, repmat(countid, length(channeltmp), 1));
 
     %     channelrecses = cat(2,channelrecses,repmat(countid,1,size(channelpostmp,1)));
     %     channelpos = cat(1,channelpos,channelpostmp);
@@ -324,65 +352,68 @@ for subsesid=1:length(KiloSortPaths)
 
     if Params.RunQualityMetrics
         theseuniqueTemplates = [];
-        unitTypeAcrossRec= [];
+        unitTypeAcrossRec = [];
 
         %% Quality metrics - Bombcell (https://github.com/Julie-Fabre/bombcell)
         for id = 1:length(rawD)
             ephysap_tmp = [];
-            ephysap_path = fullfile(rawD(id).folder,rawD(id).name);
-            if length(rawD)>1
-                savePath = fullfile(myClusFile(1).folder,num2str(id));
-            else
-                savePath =myClusFile(1).folder;
-            end
+
+            ephysap_path = fullfile(rawD(id).folder, rawD(id).name);
+
+                savePath = fullfile(KiloSortPaths{subsesid});
+
             qMetricsExist = ~isempty(dir(fullfile(savePath, '**', 'templates._bc_qMetrics.parquet'))); % ~isempty(dir(fullfile(savePath, 'qMetric*.mat'))) not used anymore?
-            idx = sp.SessionID==id;
+            idx = sp.SessionID == 1;
             InspectionFlag = 0;
-            if ~exist(fullfile(rawD(id).folder,strrep(rawD(id).name,'.cbin','_sync.dat')))
+            if ~exist(fullfile(Params.tmpdatafolder, strrep(rawD(id).name, 'cbin', 'bin'))) %&& Params.extractSync
                 disp('Extracting sync file...')
                 % detect whether data is compressed, decompress locally if necessary
-                if ~exist(fullfile(Params.tmpdatafolder,strrep(rawD(id).name,'cbin','bin')))
+                if ~exist(fullfile(Params.tmpdatafolder, strrep(rawD(id).name, 'cbin', 'bin')))
                     disp('This is compressed data and we do not want to use Python integration... uncompress temporarily')
-                    decompDataFile = bc_extractCbinData(fullfile(rawD(id).folder,rawD(id).name),...
-                        [], [], 0,  fullfile(Params.tmpdatafolder,strrep(rawD(id).name,'cbin','bin')));
-                    copyfile(strrep(fullfile(rawD(id).folder,rawD(id).name),'cbin','meta'),strrep(fullfile(Params.tmpdatafolder,rawD(id).name),'cbin','meta'))
+                    decompDataFile = bc_extractCbinData(fullfile(rawD(id).folder, rawD(id).name), ...
+                        [], [], 0, fullfile(Params.tmpdatafolder, strrep(rawD(id).name, 'cbin', 'bin')));
+                    status = copyfile(strrep(fullfile(rawD(id).folder, rawD(id).name), 'cbin', 'meta'), strrep(fullfile(Params.tmpdatafolder, rawD(id).name), 'cbin', 'meta')); %QQ doesn't work on linux
                 end
                 DecompressionFlag = 1;
-                [Imecmeta] = ReadMeta2(fullfile(Params.tmpdatafolder,strrep(rawD(id).name,'cbin','meta')),'ap');
-                nchan = strsplit(Imecmeta.acqApLfSy,',');
-                nChansInFile = str2num(nchan{1})+str2num(nchan{3});
-          
-                syncDatImec = extractSyncChannel(fullfile(Params.tmpdatafolder,strrep(rawD(id).name,'cbin','bin')), nChansInFile, nChansInFile); %Last channel is sync
-                copyfile(fullfile(Params.tmpdatafolder,strrep(rawD(id).name,'.cbin','_sync.dat')),fullfile(rawD(id).folder,strrep(rawD(id).name,'.cbin','_sync.dat')))
+                 if status == 0 %could not copy meta file - use original meta file 
+                     [Imecmeta] = ReadMeta2(fullfile(rawD(id).folder, strrep(rawD(id).name, 'cbin', 'meta')), 'ap');
+                 else
+                    [Imecmeta] = ReadMeta2(fullfile(Params.tmpdatafolder, strrep(rawD(id).name, 'cbin', 'meta')), 'ap');
+                end
+                nchan = strsplit(Imecmeta.acqApLfSy, ',');
+                nChansInFile = str2num(nchan{1}) + str2num(nchan{3});
+
+                syncDatImec = extractSyncChannel(fullfile(Params.tmpdatafolder, strrep(rawD(id).name, 'cbin', 'bin')), nChansInFile, nChansInFile); %Last channel is sync
+                status = copyfile(fullfile(Params.tmpdatafolder, strrep(rawD(id).name, '.cbin', '_sync.dat')), fullfile(rawD(id).folder, strrep(rawD(id).name, '.cbin', '_sync.dat'))); %QQ doesn't work on linux
 
             end
             if ~qMetricsExist || Params.RedoQM
                 % First check if we want to use python for compressed data. If not, uncompress data first
-                if any(strfind(rawD(id).name,'cbin')) && Params.DecompressLocal
+                if any(strfind(rawD(id).name, 'cbin')) && Params.DecompressLocal
                     % detect whether data is compressed, decompress locally if necessary
-                    if ~exist(fullfile(Params.tmpdatafolder,strrep(rawD(id).name,'cbin','bin')))
+                    if ~exist(fullfile(Params.tmpdatafolder, strrep(rawD(id).name, 'cbin', 'bin')))
                         disp('This is compressed data and we do not want to use Python integration... uncompress temporarily')
-                        decompDataFile = bc_extractCbinData(fullfile(rawD(id).folder,rawD(id).name),...
-                            [], [], 0,  fullfile(Params.tmpdatafolder,strrep(rawD(id).name,'cbin','bin')));
-                        copyfile(strrep(fullfile(rawD(id).folder,rawD(id).name),'cbin','meta'),strrep(fullfile(Params.tmpdatafolder,rawD(id).name),'cbin','meta'))
+                        decompDataFile = bc_extractCbinData(fullfile(rawD(id).folder, rawD(id).name), ...
+                            [], [], 0, fullfile(Params.tmpdatafolder, strrep(rawD(id).name, 'cbin', 'bin')));
+                        status = copyfile(strrep(fullfile(rawD(id).folder, rawD(id).name), 'cbin', 'meta'), strrep(fullfile(Params.tmpdatafolder, rawD(id).name), 'cbin', 'meta')); %QQ doesn't work on linux
                     end
-                  
+
                     DecompressionFlag = 1;
                     if Params.InspectQualityMetrics
-                        InspectionFlag=1;
+                        InspectionFlag = 1;
                     end
                 end
 
-                paramBC.rawFile = fullfile(Params.tmpdatafolder,strrep(rawD(id).name,'cbin','bin'));
-                paramBC.ephysMetaFile = (strrep(fullfile(Params.tmpdatafolder,rawD(id).name),'cbin','meta'));
+                paramBC.rawFile = fullfile(Params.tmpdatafolder, strrep(rawD(id).name, 'cbin', 'bin'));
+                paramBC.ephysMetaFile = (strrep(fullfile(rawD(id).folder, rawD(id).name), 'cbin', 'meta'));
 
                 %             idx = ismember(sp.spikeTemplates,clusidtmp(Good_IDtmp)); %Only include good units
                 %careful; spikeSites zero indexed
                 [qMetric, unitType] = bc_runAllQualityMetrics(paramBC, sp.st(idx)*sp.sample_rate, sp.spikeTemplates(idx)+1, ...
-                    sp.temps, sp.tempScalingAmps(idx),sp.pcFeat(idx,:,:),sp.pcFeatInd+1,channelpostmp, savePath); % Be careful, bombcell needs 1-indexed!
+                    templateWaveforms, sp.tempScalingAmps(idx), sp.pcFeat(idx, :, :), sp.pcFeatInd+1, channelpostmp, savePath); % Be careful, bombcell needs 1-indexed!
 
             else
-                paramBC.rawFile = fullfile(Params.tmpdatafolder,strrep(rawD(id).name,'cbin','bin'));
+                paramBC.rawFile = fullfile(Params.tmpdatafolder, strrep(rawD(id).name, 'cbin', 'bin'));
                 if exist('ephysap_tmp', 'var')
                     paramBC.tmpFolder = [ephysap_tmp, '/..'];
                 end
@@ -390,9 +421,9 @@ for subsesid=1:length(KiloSortPaths)
                 qMetricsPath = d.folder;
                 [~, qMetric, fractionRPVs_allTauR] = bc_loadSavedMetrics(qMetricsPath);
                 unitType = bc_getQualityUnitType(paramBC, qMetric);
-%                 unitType(:) = 1; ???
-                
-                %{ 
+                %                 unitType(:) = 1; ???
+
+                %{
                 % Commmented by CB for now    
                 spike_templates_0idx = readNPY([savePath filesep 'spike_templates.npy']);
                 spikeTemplates = spike_templates_0idx + 1;
@@ -410,6 +441,7 @@ for subsesid=1:length(KiloSortPaths)
 
             if InspectionFlag % Doesn't currently work: Julie will update bombcell
                 bc_loadMetricsForGUI
+
                 %% Inspect the results?
                 % GUI guide:
                 % left/right arrow: toggle between units
@@ -428,10 +460,11 @@ for subsesid=1:length(KiloSortPaths)
                 end
                 disp('GUI closed')
             end
+
             %% Apply QM findings:
             disp('Only use units that passed the quality metrics parameters')
             % This is necessary inside this loop when running stitched - don't change!!
-            Good_IDtmp = nan(1,length(Good_IDtmp)); % Replace with unitType
+            Good_IDtmp = nan(1, length(Good_IDtmp)); % Replace with unitType
             Good_IDtmp(qMetricclusterID(unitType ~= 1)) = 0; % MUA
             Good_IDtmp(qMetricclusterID(unitType == 1)) = 1; % Good
             Good_IDtmp(qMetricclusterID(unitType == 0)) = 0; % MUA
@@ -439,38 +472,38 @@ for subsesid=1:length(KiloSortPaths)
             %         NoiseUnit = false(size(Good_IDtmp));
             %         NoiseUnit(unitType == 0)=1; % NOISE
 
-           
-            Good_ID = [Good_ID,Good_IDtmp]; %Identify good clusters
+
+            Good_ID = [Good_ID, Good_IDtmp]; %Identify good clusters
 
         end
-       
-        AllUniqueTemplates = cat(1,AllUniqueTemplates(:),cat(1,theseuniqueTemplates{:}));
+
+        AllUniqueTemplates = cat(1, AllUniqueTemplates(:), cat(1, theseuniqueTemplates{:}));
 
     else
-        AllUniqueTemplates = cat(1,AllUniqueTemplates,unique(sp.spikeTemplates));
-        Good_ID = [Good_ID,Good_IDtmp]; %Identify good clusters
+        AllUniqueTemplates = cat(1, AllUniqueTemplates, unique(sp.spikeTemplates));
+        Good_ID = [Good_ID, Good_IDtmp]; %Identify good clusters
 
         %         NoiseUnit = false(size(Good_IDtmp));
     end
     addthis = nanmax(recsesAll);
     if isempty(addthis)
-        addthis=0;
+        addthis = 0;
     end
-    if exist('theseuniqueTemplates','var') && iscell(theseuniqueTemplates)
-        recsesAlltmp = arrayfun(@(X) repmat(addthis+X,1,length(theseuniqueTemplates{X})),[1:length(theseuniqueTemplates)],'UniformOutput',0);
-        recsesAll =cat(1,recsesAll(:), cat(2,recsesAlltmp{:})');
-        ProbeAll = cat(1,ProbeAll(:),repmat(probeid,1,length(cat(2,recsesAlltmp{:})))');
+    if exist('theseuniqueTemplates', 'var') && iscell(theseuniqueTemplates)
+        recsesAlltmp = arrayfun(@(X) repmat(addthis+X, 1, length(theseuniqueTemplates{X})), [1:length(theseuniqueTemplates)], 'UniformOutput', 0);
+        recsesAll = cat(1, recsesAll(:), cat(2, recsesAlltmp{:})');
+        ProbeAll = cat(1, ProbeAll(:), repmat(probeid, 1, length(cat(2, recsesAlltmp{:})))');
     else
-        recsesAll = cat(1,recsesAll(:),repmat(addthis+1,1,length(Good_IDtmp))');
-        ProbeAll = cat(1,ProbeAll(:),repmat(probeid,1,length(Good_IDtmp))');
+        recsesAll = cat(1, recsesAll(:), repmat(addthis+1, 1, length(Good_IDtmp))');
+        ProbeAll = cat(1, ProbeAll(:), repmat(probeid, 1, length(Good_IDtmp))');
     end
-    sp.RecSes = sp.SessionID+countid-1; %Keep track of recording session, as cluster IDs are not unique across sessions
+    sp.RecSes = sp.SessionID + countid - 1; %Keep track of recording session, as cluster IDs are not unique across sessions
 
     %% Save out sp and clusinfo for this session in the correct folder
     ShankOpt = unique(Shank);
     ShankID = nan(size(Shank));
     for shankid = 1:length(ShankOpt)
-        ShankID(Shank==ShankOpt(shankid))=shankid;
+        ShankID(Shank == ShankOpt(shankid)) = shankid;
     end
     clusinfo.Shank = Shank;
     clusinfo.ProbeID = ProbeAll;
@@ -481,8 +514,8 @@ for subsesid=1:length(KiloSortPaths)
     clusinfo.cluster_id = AllUniqueTemplates;
     clusinfo.group = Label;
     clusinfo.Good_ID = Good_ID;
-    if exist('Depth2AreaPerUnit','var') % Add area information
-        Idx = cell2mat(arrayfun(@(X) find(Depth2AreaPerUnit.Cluster_ID-1 == X),clusinfo.cluster_id,'Uni',0));
+    if exist('Depth2AreaPerUnit', 'var') % Add area information
+        Idx = cell2mat(arrayfun(@(X) find(Depth2AreaPerUnit.Cluster_ID-1 == X), clusinfo.cluster_id, 'Uni', 0));
         clusinfo.Area = Depth2AreaPerUnit.Area(Idx);
         clusinfo.Coordinates = Depth2AreaPerUnit.Coordinates(Idx);
         if length(clusinfo.Coordinates) ~= length(clusinfo.cluster_id)
@@ -495,38 +528,39 @@ for subsesid=1:length(KiloSortPaths)
     sp.sample_rate = sp.sample_rate(1);
 
     % Clean up unnecessary information in sp
-    sp = rmfield(sp,'tempScalingAmps');
-    sp = rmfield(sp,'temps');
-    sp = rmfield(sp,'winv');
-    sp = rmfield(sp,'pcFeat');
-    sp = rmfield(sp,'pcFeatInd');
-    sp = rmfield(sp,'tempAmps');
-    sp = rmfield(sp,'tempsUnW');
-    sp = rmfield(sp,'templateDuration');
-    sp = rmfield(sp,'waveforms');
-    save(fullfile(KiloSortPaths{subsesid},'PreparedData.mat'),'clusinfo','Params','-v7.3')
-    if Params.saveSp
+    sp = rmfield(sp, 'tempScalingAmps');
+    sp = rmfield(sp, 'temps');
+    sp = rmfield(sp, 'winv');
+    sp = rmfield(sp, 'pcFeat');
+    sp = rmfield(sp, 'pcFeatInd');
+    sp = rmfield(sp, 'tempAmps');
+    sp = rmfield(sp, 'tempsUnW');
+    sp = rmfield(sp, 'templateDuration');
+    sp = rmfield(sp, 'waveforms');
+    save(fullfile(KiloSortPaths{subsesid}, 'PreparedData.mat'), 'clusinfo', 'Params', '-v7.3')
+    if Params.saveSp %QQ not using savePaths
         try
-        save(fullfile(KiloSortPaths{subsesid},'PreparedData.mat'),'sp','-append')
+            save(fullfile(KiloSortPaths{subsesid}, 'PreparedData.mat'), 'sp', '-append')
         catch ME
             disp(ME)
         end
     end
 
-    countid=countid+1;
+    countid = countid + 1;
 end
 
 Params.AllChannelPos = AllChannelPos;
 Params.RawDataPaths = RawDataPaths;
 Params.DecompressionFlag = DecompressionFlag;
+
 %% Remove temporary files
-if 0%Params.DecompressLocal && DecompressionFlag
+if 0 %Params.DecompressLocal && DecompressionFlag
     clear memMapData
     clear ap_data
     try
         for id = 1:length(RawDataPaths)
-            delete(fullfile(Params.tmpdatafolder,strrep(RawDataPaths(id).name,'cbin','bin')))
-            delete(fullfile(Params.tmpdatafolder,strrep(RawDataPaths(id).name,'cbin','meta')))
+            delete(fullfile(Params.tmpdatafolder, strrep(RawDataPaths(id).name, 'cbin', 'bin')))
+            delete(fullfile(Params.tmpdatafolder, strrep(RawDataPaths(id).name, 'cbin', 'meta')))
         end
     catch ME
         keyboard
@@ -534,6 +568,3 @@ if 0%Params.DecompressLocal && DecompressionFlag
 end
 
 return
-
-
-

--- a/Dependencies/Paper_Figures/ComputeFunctionalScores.m
+++ b/Dependencies/Paper_Figures/ComputeFunctionalScores.m
@@ -1,6 +1,6 @@
 function ComputeFunctionalScores(SaveDir)
 
-TmpFile = matfile(fullfile(SaveDir,'UnitMatch.mat')); % Access saved file
+TmpFile = matfile(fullfile(SaveDir, 'UnitMatch.mat')); % Access saved file
 UMparam = TmpFile.UMparam; % Extract parameters
 UMparam.binsz = 0.01; % Binsize in time (s) for the cross-correlation fingerprint. We recommend ~2-10ms time windows
 
@@ -12,7 +12,7 @@ UniqueIDConversion = TmpFile.UniqueIDConversion;
 if UMparam.GoodUnitsOnly
     GoodId = logical(UniqueIDConversion.GoodID);
 else
-    GoodId = true(1,length(UniqueIDConversion.GoodID));
+    GoodId = true(1, length(UniqueIDConversion.GoodID));
 end
 UniqueID = UniqueIDConversion.UniqueID(GoodId);
 OriID = UniqueIDConversion.OriginalClusID(GoodId);
@@ -26,9 +26,9 @@ nclus = length(UniqueID);
 % Load SP
 disp('Loading spike information...')
 nKSFiles = length(AllKSDir);
-sp = cell(1,nKSFiles);
+sp = cell(1, nKSFiles);
 for did = 1:nKSFiles
-    tmp = matfile(fullfile(AllKSDir{did},'PreparedData.mat'));
+    tmp = matfile(fullfile(AllKSDir{did}, 'PreparedData.mat'));
     sptmp = tmp.sp;
     clear tmp
 
@@ -40,7 +40,7 @@ for did = 1:nKSFiles
     if UMparam.RunPyKSChronicStitched
         sp{did}.RecSes = sptmp.RecSes;
     else
-        sp{did}.RecSes = repmat(did,size(sp{did}.st));
+        sp{did}.RecSes = repmat(did, size(sp{did}.st));
     end
 end
 clear sptmp
@@ -50,17 +50,17 @@ clear sptmp
 sp = [sp{:}];
 spnew = struct;
 fields = fieldnames(sp(1));
-for fieldid=1:length(fields)
+for fieldid = 1:length(fields)
     try
-        eval(['spnew.' fields{fieldid} '= cat(1,sp(:).' fields{fieldid} ');'])
+        eval(['spnew.', fields{fieldid}, '= cat(1,sp(:).', fields{fieldid}, ');'])
     catch ME
-        if strcmp(ME.message,'Out of memory.')
-            eval(['spnew.' fields{fieldid} ' = sp(1).' fields{fieldid} ';'])
+        if strcmp(ME.message, 'Out of memory.')
+            eval(['spnew.', fields{fieldid}, ' = sp(1).', fields{fieldid}, ';'])
             for tmpid = 2:length(sp)
-                eval(['spnew.' fields{fieldid} ' = cat(1,spnew.' fields{fieldid} ', sp(tmpid).' fields{fieldid} ');'])
+                eval(['spnew.', fields{fieldid}, ' = cat(1,spnew.', fields{fieldid}, ', sp(tmpid).', fields{fieldid}, ');'])
             end
         else
-            eval(['spnew.' fields{fieldid} '= cat(2,sp(:).' fields{fieldid} ');'])
+            eval(['spnew.', fields{fieldid}, '= cat(2,sp(:).', fields{fieldid}, ');'])
         end
     end
 end
@@ -69,43 +69,43 @@ clear spnew
 
 nRec = length(unique(UniqueIDConversion.recsesAll(logical(UniqueIDConversion.GoodID))));
 RecOpt = unique(UniqueIDConversion.recsesAll(logical(UniqueIDConversion.GoodID)));
-EuclDist = reshape(MatchTable.EucledianDistance,nclus,nclus);
-SessionSwitch = arrayfun(@(X) find(recses==X,1,'first'),unique(UniqueIDConversion.recsesAll(logical(UniqueIDConversion.GoodID))),'Uni',0);
-SessionSwitch(cellfun(@isempty,SessionSwitch))=[];
-SessionSwitch = [cell2mat(SessionSwitch); nclus+1];
+EuclDist = reshape(MatchTable.EucledianDistance, nclus, nclus);
+SessionSwitch = arrayfun(@(X) find(recses == X, 1, 'first'), unique(UniqueIDConversion.recsesAll(logical(UniqueIDConversion.GoodID))), 'Uni', 0);
+SessionSwitch(cellfun(@isempty, SessionSwitch)) = [];
+SessionSwitch = [cell2mat(SessionSwitch); nclus + 1];
 
 % Plotting order (sort units based on distance)
-[~,SortingOrder] = arrayfun(@(X) sort(EuclDist(1,SessionSwitch(X):SessionSwitch(X+1)-1)),1:nRec,'Uni',0);
-SortingOrder = arrayfun(@(X) squeeze(SortingOrder{X}+SessionSwitch(X)-1),1:nRec,'Uni',0);
-if size(SortingOrder{1},1)==1
-    SortingOrder = cat(2,SortingOrder{:});
+[~, SortingOrder] = arrayfun(@(X) sort(EuclDist(1, SessionSwitch(X):SessionSwitch(X+1)-1)), 1:nRec, 'Uni', 0);
+SortingOrder = arrayfun(@(X) squeeze(SortingOrder{X}+SessionSwitch(X)-1), 1:nRec, 'Uni', 0);
+if size(SortingOrder{1}, 1) == 1
+    SortingOrder = cat(2, SortingOrder{:});
 else
-    SortingOrder = cat(1,SortingOrder{:});
+    SortingOrder = cat(1, SortingOrder{:});
 end
-if ~any(ismember(MatchTable.Properties.VariableNames,'FingerprintCor')) % If it already exists in table, skip this entire thing
+if ~any(ismember(MatchTable.Properties.VariableNames, 'FingerprintCor')) % If it already exists in table, skip this entire thing
 
     %% Compute cross-correlation matrices for individual recordings
     disp('Computing cross-correlation fingerprint')
-    SessionCorrelations = cell(1,nRec);
+    SessionCorrelations = cell(1, nRec);
     for rid = 1:nRec
         % Define edges for this dataset
-        edges = floor(min(sp.st(sp.RecSes==RecOpt(rid))))-UMparam.binsz/2:UMparam.binsz:ceil(max(sp.st(sp.RecSes==RecOpt(rid))))+UMparam.binsz/2;
-        Good_Idx = find(GoodId & recsesall'==RecOpt(rid)); % Only care about good units at this point
+        edges = floor(min(sp.st(sp.RecSes == RecOpt(rid)))) - UMparam.binsz / 2:UMparam.binsz:ceil(max(sp.st(sp.RecSes == RecOpt(rid)))) + UMparam.binsz / 2;
+        Good_Idx = find(GoodId & recsesall' == RecOpt(rid)); % Only care about good units at this point
 
         % bin data to create PSTH
-        sr = nan(numel(Good_Idx),numel(edges)-1);
+        sr = nan(numel(Good_Idx), numel(edges)-1);
         for uid = 1:numel(Good_Idx)
-            sr(uid,:) =  histcounts(sp.st(sp.spikeTemplates == OriIDAll(Good_Idx(uid)) & sp.RecSes == recsesall(Good_Idx(uid))),edges);
+            sr(uid, :) = histcounts(sp.st(sp.spikeTemplates == OriIDAll(Good_Idx(uid)) & sp.RecSes == recsesall(Good_Idx(uid))), edges);
         end
 
         % Define folds (two halves)
-        idx_fold1 = 1:floor(size(sr,2)./2);
-        idx_fold2 = floor(size(sr,2)./2)+1:floor(size(sr,2)./2)*2;
+        idx_fold1 = 1:floor(size(sr, 2)./2);
+        idx_fold2 = floor(size(sr, 2)./2) + 1:floor(size(sr, 2)./2) * 2;
 
         % Find cross-correlation in first and second half of session
         try
-            SessionCorrelations{rid}.fold1 = corr(sr(:,idx_fold1)',sr(:,idx_fold1)')';
-            SessionCorrelations{rid}.fold2 = corr(sr(:,idx_fold2)',sr(:,idx_fold2)')';
+            SessionCorrelations{rid}.fold1 = corr(sr(:, idx_fold1)', sr(:, idx_fold1)')';
+            SessionCorrelations{rid}.fold2 = corr(sr(:, idx_fold2)', sr(:, idx_fold2)')';
         catch
             keyboard
         end
@@ -116,17 +116,17 @@ if ~any(ismember(MatchTable.Properties.VariableNames,'FingerprintCor')) % If it 
     end
 
     %% Get correlation matrics for fingerprint correlations
-    sessionCorrelationsAll = cell(1,nRec);
+    sessionCorrelationsAll = cell(1, nRec);
     for did = 1:nRec
         % Load sp for correct day
-        if length(AllKSDir)>1
-            tmp = matfile(fullfile(AllKSDir{did},'PreparedData.mat'));
+        if length(AllKSDir) > 1
+            tmp = matfile(fullfile(AllKSDir{did}, 'PreparedData.mat'));
         else %Stitched
-            tmp = matfile(fullfile(AllKSDir{1},'PreparedData.mat'));
+            tmp = matfile(fullfile(AllKSDir{1}, 'PreparedData.mat'));
         end
-        if length(SessionCorrelations)==nRec
+        if length(SessionCorrelations) == nRec
             sessionCorrelationsAll{did} = SessionCorrelations{did};
-        elseif length(SessionCorrelations)==1  %Normal situation
+        elseif length(SessionCorrelations) == 1 %Normal situation
             if iscell(SessionCorrelations)
                 sessionCorrelationsAll{did} = SessionCorrelations{1};
             else
@@ -139,17 +139,17 @@ if ~any(ismember(MatchTable.Properties.VariableNames,'FingerprintCor')) % If it 
     end
 
     %% Compute functional score (cross-correlation fingerprint)
-    if nRec<5
+    if nRec < 5
         drawdrosscorr = 1;
     else
         drawdrosscorr = 0;
     end
-    MatchProbability = reshape(MatchTable.MatchProb,nclus,nclus);
-    [r, c] = find(MatchProbability>UMparam.ProbabilityThreshold); %Find matches
-    Pairs = cat(2,r,c);
+    MatchProbability = reshape(MatchTable.MatchProb, nclus, nclus);
+    [r, c] = find(MatchProbability > UMparam.ProbabilityThreshold); %Find matches
+    Pairs = cat(2, r, c);
     Pairs = sortrows(Pairs);
-    Pairs = unique(Pairs,'rows');
-    [FingerprintR,RankScoreAll,SigMask,AllSessionCorrelations] = CrossCorrelationFingerPrint(sessionCorrelationsAll,Pairs,OriID,recses,drawdrosscorr);
+    Pairs = unique(Pairs, 'rows');
+    [FingerprintR, RankScoreAll, SigMask, AllSessionCorrelations] = CrossCorrelationFingerPrint(sessionCorrelationsAll, Pairs, OriID, recses, drawdrosscorr);
 
     % Save in table
     MatchTable.FingerprintCor = FingerprintR(:);
@@ -162,55 +162,54 @@ if ~any(ismember(MatchTable.Properties.VariableNames,'FingerprintCor')) % If it 
     TmpFile.AllSessionCorrelations = AllSessionCorrelations;
     TmpFile.Properties.Writable = false;
 
-
     %% Compare to functional scores
 
     figure;
 
-    subplot(1,3,1)
-    imagesc(RankScoreAll(SortingOrder,SortingOrder)==1 & SigMask(SortingOrder,SortingOrder)==1)
+    subplot(1, 3, 1)
+    imagesc(RankScoreAll(SortingOrder, SortingOrder) == 1 & SigMask(SortingOrder, SortingOrder) == 1)
     hold on
-    arrayfun(@(X) line([SessionSwitch(X) SessionSwitch(X)],get(gca,'ylim'),'color',[1 0 0]),2:length(SessionSwitch),'Uni',0)
-    arrayfun(@(X) line(get(gca,'xlim'),[SessionSwitch(X) SessionSwitch(X)],'color',[1 0 0]),2:length(SessionSwitch),'Uni',0)
+    arrayfun(@(X) line([SessionSwitch(X), SessionSwitch(X)], get(gca, 'ylim'), 'color', [1, 0, 0]), 2:length(SessionSwitch), 'Uni', 0)
+    arrayfun(@(X) line(get(gca, 'xlim'), [SessionSwitch(X), SessionSwitch(X)], 'color', [1, 0, 0]), 2:length(SessionSwitch), 'Uni', 0)
     colormap(flipud(gray))
     title('Rankscore == 1*')
     makepretty
 
-    subplot(1,3,2)
-    imagesc(MatchProbability(SortingOrder,SortingOrder)>UMparam.ProbabilityThreshold)
+    subplot(1, 3, 2)
+    imagesc(MatchProbability(SortingOrder, SortingOrder) > UMparam.ProbabilityThreshold)
     hold on
-    arrayfun(@(X) line([SessionSwitch(X) SessionSwitch(X)],get(gca,'ylim'),'color',[1 0 0]),2:length(SessionSwitch),'Uni',0)
-    arrayfun(@(X) line(get(gca,'xlim'),[SessionSwitch(X) SessionSwitch(X)],'color',[1 0 0]),2:length(SessionSwitch),'Uni',0)
+    arrayfun(@(X) line([SessionSwitch(X), SessionSwitch(X)], get(gca, 'ylim'), 'color', [1, 0, 0]), 2:length(SessionSwitch), 'Uni', 0)
+    arrayfun(@(X) line(get(gca, 'xlim'), [SessionSwitch(X), SessionSwitch(X)], 'color', [1, 0, 0]), 2:length(SessionSwitch), 'Uni', 0)
     colormap(flipud(gray))
-    title(['Match Probability>' num2str(UMparam.ProbabilityThreshold)])
+    title(['Match Probability>', num2str(UMparam.ProbabilityThreshold)])
     makepretty
 
-    subplot(1,3,3)
-    imagesc(MatchProbability(SortingOrder,SortingOrder)>=UMparam.ProbabilityThreshold | (MatchProbability(SortingOrder,SortingOrder)>0.05 & RankScoreAll(SortingOrder,SortingOrder)==1 & SigMask(SortingOrder,SortingOrder)==1));
+    subplot(1, 3, 3)
+    imagesc(MatchProbability(SortingOrder, SortingOrder) >= UMparam.ProbabilityThreshold | (MatchProbability(SortingOrder, SortingOrder) > 0.05 & RankScoreAll(SortingOrder, SortingOrder) == 1 & SigMask(SortingOrder, SortingOrder) == 1));
     % imagesc(MatchProbability>=0.99 | (MatchProbability>=0.05 & RankScoreAll==1 & SigMask==1))
     hold on
-    arrayfun(@(X) line([SessionSwitch(X) SessionSwitch(X)],get(gca,'ylim'),'color',[1 0 0]),2:length(SessionSwitch),'Uni',0)
-    arrayfun(@(X) line(get(gca,'xlim'),[SessionSwitch(X) SessionSwitch(X)],'color',[1 0 0]),2:length(SessionSwitch),'Uni',0)
+    arrayfun(@(X) line([SessionSwitch(X), SessionSwitch(X)], get(gca, 'ylim'), 'color', [1, 0, 0]), 2:length(SessionSwitch), 'Uni', 0)
+    arrayfun(@(X) line(get(gca, 'xlim'), [SessionSwitch(X), SessionSwitch(X)], 'color', [1, 0, 0]), 2:length(SessionSwitch), 'Uni', 0)
     colormap(flipud(gray))
     title('Matching probability + rank')
     makepretty
-    saveas(gcf,fullfile(SaveDir,'RankScoreVSProbability.fig'))
-    saveas(gcf,fullfile(SaveDir,'RankScoreVSProbability.bmp'))
+    saveas(gcf, fullfile(SaveDir, 'RankScoreVSProbability.fig'))
+    saveas(gcf, fullfile(SaveDir, 'RankScoreVSProbability.bmp'))
 
     tmpf = triu(FingerprintR);
     tmpm = triu(MatchProbability);
     tmpr = triu(RankScoreAll);
-    tmpr = tmpr(tmpf~=0);
-    tmpm = tmpm(tmpf~=0);
-    tmpf = tmpf(tmpf~=0);
+    tmpr = tmpr(tmpf ~= 0);
+    tmpm = tmpm(tmpf ~= 0);
+    tmpf = tmpf(tmpf ~= 0);
     figure;
-    scatter(tmpm,tmpf,14,tmpr,'filled')
-    colormap(cat(1,[0 0 0],winter))
+    scatter(tmpm, tmpf, 14, tmpr, 'filled')
+    colormap(cat(1, [0, 0, 0], winter))
     xlabel('Match Probability')
     ylabel('Cross-correlation fingerprint')
     makepretty
-    saveas(gcf,fullfile(SaveDir,'RankScoreVSProbabilityScatter.fig'))
-    saveas(gcf,fullfile(SaveDir,'RankScoreVSProbabilityScatter.bmp'))
+    saveas(gcf, fullfile(SaveDir, 'RankScoreVSProbabilityScatter.fig'))
+    saveas(gcf, fullfile(SaveDir, 'RankScoreVSProbabilityScatter.bmp'))
 end
 % Extract groups
 if UMparam.RunPyKSChronicStitched
@@ -234,104 +233,105 @@ for id = 1:ntimes
         disp('No Matches found... return')
         return
     end
-    %% Cross-correlation ROC?
-    figure('name',['Functional score separatability ' addname])
 
-    subplot(3,3,1)
-    imagesc(reshape(MatchTable.FingerprintCor,nclus,nclus))
+    %% Cross-correlation ROC?
+    figure('name', ['Functional score separatability ', addname])
+
+    subplot(3, 3, 1)
+    imagesc(reshape(MatchTable.FingerprintCor, nclus, nclus))
     hold on
     colormap(flipud(gray))
     makepretty
     xlabel('Unit_i')
     ylabel('Unit_j')
     hold on
-    arrayfun(@(X) line([SessionSwitch(X) SessionSwitch(X)],get(gca,'ylim'),'color',[1 0 0]),2:length(SessionSwitch),'Uni',0)
-    arrayfun(@(X) line(get(gca,'xlim'),[SessionSwitch(X) SessionSwitch(X)],'color',[1 0 0]),2:length(SessionSwitch),'Uni',0)
+    arrayfun(@(X) line([SessionSwitch(X), SessionSwitch(X)], get(gca, 'ylim'), 'color', [1, 0, 0]), 2:length(SessionSwitch), 'Uni', 0)
+    arrayfun(@(X) line(get(gca, 'xlim'), [SessionSwitch(X), SessionSwitch(X)], 'color', [1, 0, 0]), 2:length(SessionSwitch), 'Uni', 0)
     title('Cross-correlation Fingerprint')
     axis square
     freezeColors
 
-    FingerprintCor = reshape(MatchTable.FingerprintCor,nclus,nclus);
+    FingerprintCor = reshape(MatchTable.FingerprintCor, nclus, nclus);
     % Subtr = repmat(diag(FingerprintCor),1,size(FingerprintCor,1));
     % FingerprintCor = FingerprintCor - Subtr; % Subtract diagonalcorrelations
 
-    subplot(3,3,2)
+    subplot(3, 3, 2)
     bins = min(FingerprintCor(:)):0.1:max(FingerprintCor(:));
-    Vector = [bins(1)+0.1/2:0.1:bins(end)-0.1/2];
-    hw = histcounts(FingerprintCor(WithinIdx),bins)./length(WithinIdx);
-    hm = histcounts(FingerprintCor(MatchIdx),bins)./length(MatchIdx);
-    hn = histcounts(FingerprintCor(NonMatchIdx),bins)./length(NonMatchIdx);
-    plot(Vector,hw,'color',[0.5 0.5 0.5])
+    Vector = [bins(1) + 0.1 / 2:0.1:bins(end) - 0.1 / 2];
+    hw = histcounts(FingerprintCor(WithinIdx), bins) ./ length(WithinIdx);
+    hm = histcounts(FingerprintCor(MatchIdx), bins) ./ length(MatchIdx);
+    hn = histcounts(FingerprintCor(NonMatchIdx), bins) ./ length(NonMatchIdx);
+    plot(Vector, hw, 'color', [0.5, 0.5, 0.5])
     hold on
-    plot(Vector,hm,'color',[0 0.5 0])
-    plot(Vector,hn,'color',[0 0 0])
+    plot(Vector, hm, 'color', [0, 0.5, 0])
+    plot(Vector, hn, 'color', [0, 0, 0])
     xlabel('Cross-correlation Fingerprint')
     ylabel('Proportion|Group')
-    legend('i=j; within recording','matches','non-matches','Location','best')
+    legend('i=j; within recording', 'matches', 'non-matches', 'Location', 'best')
     axis square
     makepretty
 
-    subplot(3,3,3)
-    labels = [ones(1,numel(MatchIdx)), zeros(1,numel(NonMatchIdx))];
+    subplot(3, 3, 3)
+    labels = [ones(1, numel(MatchIdx)), zeros(1, numel(NonMatchIdx))];
     scores = [FingerprintCor(MatchIdx)', FingerprintCor(NonMatchIdx)'];
-    [X,Y,~,AUC1] = perfcurve(labels,scores,1);
-    h(1) = plot(X,Y,'color',[0 0.25 0]);
+    [X, Y, ~, AUC1] = perfcurve(labels, scores, 1);
+    h(1) = plot(X, Y, 'color', [0, 0.25, 0]);
     hold all
-    labels = [ones(1,numel(MatchIdx)), zeros(1,numel(WithinIdx))];
+    labels = [ones(1, numel(MatchIdx)), zeros(1, numel(WithinIdx))];
     scores = [FingerprintCor(MatchIdx)', FingerprintCor(WithinIdx)'];
-    [X,Y,~,AUC2] = perfcurve(labels,scores,1);
-    h(2) = plot(X,Y,'color',[0 0.5 0]);
-    labels = [ones(1,numel(WithinIdx)), zeros(1,numel(NonMatchIdx))];
+    [X, Y, ~, AUC2] = perfcurve(labels, scores, 1);
+    h(2) = plot(X, Y, 'color', [0, 0.5, 0]);
+    labels = [ones(1, numel(WithinIdx)), zeros(1, numel(NonMatchIdx))];
     scores = [FingerprintCor(WithinIdx)', FingerprintCor(NonMatchIdx)'];
-    [X,Y,~,AUC3] = perfcurve(labels,scores,1);
-    h(3) = plot(X,Y,'color',[0.25 0.25 0.25]);
+    [X, Y, ~, AUC3] = perfcurve(labels, scores, 1);
+    h(3) = plot(X, Y, 'color', [0.25, 0.25, 0.25]);
     axis square
 
-    plot([0 1],[0 1],'k--')
+    plot([0, 1], [0, 1], 'k--')
     xlabel('False positive rate')
     ylabel('True positive rate')
-    legend([h(:)],'Match vs No Match','Match vs Within','Within vs No Match','Location','best')
-    title(sprintf('Cross-Correlation Fingerprint AUC: %.3f, %.3f, %.3f', AUC1,AUC2,AUC3))
+    legend([h(:)], 'Match vs No Match', 'Match vs Within', 'Within vs No Match', 'Location', 'best')
+    title(sprintf('Cross-Correlation Fingerprint AUC: %.3f, %.3f, %.3f', AUC1, AUC2, AUC3))
     makepretty
     drawnow %Something to look at while ACG calculations are ongoing
 
-    if ~any(ismember(MatchTable.Properties.VariableNames,'ACGCorr')) % If it already exists in table, skip this entire thing
+    if ~any(ismember(MatchTable.Properties.VariableNames, 'ACGCorr')) % If it already exists in table, skip this entire thing
 
         %% Compute ACG and correlate them between units
         % This is very time consuming
         disp('Computing ACG, this will take some time...')
-        tvec =  -UMparam.ACGduration/2:UMparam.ACGbinSize:UMparam.ACGduration/2;
-        ACGMat = nan(length(tvec),2,nclus);
-        FR = nan(2,nclus);
+        tvec = -UMparam.ACGduration / 2:UMparam.ACGbinSize:UMparam.ACGduration / 2;
+        ACGMat = nan(length(tvec), 2, nclus);
+        FR = nan(2, nclus);
         parfor clusid = 1:nclus
             for cv = 1:2
-                idx1=find(sp.spikeTemplates == OriID(clusid) & sp.RecSes == recses(clusid));
-                if ~isempty(idx1) && length(idx1)>UMparam.sampleamount
-                    if cv==1
+                idx1 = find(sp.spikeTemplates == OriID(clusid) & sp.RecSes == recses(clusid));
+                if ~isempty(idx1) && length(idx1) > UMparam.sampleamount
+                    if cv == 1
                         idx1 = idx1(1:floor(length(idx1)/2));
                     else
                         idx1 = idx1(ceil(length(idx1)/2):end);
                     end
 
                     % Compute Firing rate
-                    nspkspersec = histcounts(sp.st(idx1),[min(sp.st(idx1)):1:max(sp.st(idx1))]);
-                    FR(cv,clusid) = nanmean(nspkspersec);
+                    nspkspersec = histcounts(sp.st(idx1), [min(sp.st(idx1)):1:max(sp.st(idx1))]);
+                    FR(cv, clusid) = nanmean(nspkspersec);
 
                     % compute ACG
                     [ccg, t] = CCGBz([double(sp.st(idx1)); double(sp.st(idx1))], [ones(size(sp.st(idx1), 1), 1); ...
                         ones(size(sp.st(idx1), 1), 1) * 2], 'binSize', UMparam.ACGbinSize, 'duration', UMparam.ACGduration, 'norm', 'rate'); %function
-                    ACGMat(:,cv,clusid) = ccg(:, 1, 1);
+                    ACGMat(:, cv, clusid) = ccg(:, 1, 1);
                 end
             end
         end
 
         %% Correlation between ACG
-        ACGCorr = corr(squeeze(ACGMat(:,1,:)),squeeze(ACGMat(:,2,:)));
+        ACGCorr = corr(squeeze(ACGMat(:, 1, :)), squeeze(ACGMat(:, 2, :)));
         MatchTable.ACGCorr = ACGCorr(:);
 
         %% FR difference
-        FR = repmat(permute(FR,[2,1]),[1,1,nclus]);
-        FRDiff = abs(squeeze(FR(:,2,:) - permute(FR(:,1,:),[3,2,1])));
+        FR = repmat(permute(FR, [2, 1]), [1, 1, nclus]);
+        FRDiff = abs(squeeze(FR(:, 2, :)-permute(FR(:, 1, :), [3, 2, 1])));
         MatchTable.FRDiff = FRDiff(:);
 
         % Write to table
@@ -342,126 +342,126 @@ for id = 1:ntimes
     end
 
     %% Plot ACG
-    subplot(3,3,4)
-    imagesc(reshape(MatchTable.ACGCorr,nclus,nclus))
+    subplot(3, 3, 4)
+    imagesc(reshape(MatchTable.ACGCorr, nclus, nclus))
     hold on
     colormap(flipud(gray))
     makepretty
     xlabel('Unit_i')
     ylabel('Unit_j')
     hold on
-    arrayfun(@(X) line([SessionSwitch(X) SessionSwitch(X)],get(gca,'ylim'),'color',[1 0 0]),2:length(SessionSwitch),'Uni',0)
-    arrayfun(@(X) line(get(gca,'xlim'),[SessionSwitch(X) SessionSwitch(X)],'color',[1 0 0]),2:length(SessionSwitch),'Uni',0)
+    arrayfun(@(X) line([SessionSwitch(X), SessionSwitch(X)], get(gca, 'ylim'), 'color', [1, 0, 0]), 2:length(SessionSwitch), 'Uni', 0)
+    arrayfun(@(X) line(get(gca, 'xlim'), [SessionSwitch(X), SessionSwitch(X)], 'color', [1, 0, 0]), 2:length(SessionSwitch), 'Uni', 0)
     title('Autocorrelogram Correlation')
     axis square
 
     freezeColors
 
-    subplot(3,3,5)
-    ACGCor = reshape(MatchTable.ACGCorr,nclus,nclus);
+    subplot(3, 3, 5)
+    ACGCor = reshape(MatchTable.ACGCorr, nclus, nclus);
     % Subtr = repmat(diag(ACGCor),1,size(ACGCor,1));
     % ACGCor = ACGCor - Subtr; % Subtract diagonalcorrelations
     bins = min(ACGCor(:)):0.1:max(ACGCor(:));
-    Vector = [bins(1)+0.1/2:0.1:bins(end)-0.1/2];
-    hw = histcounts(ACGCor(WithinIdx),bins)./length(WithinIdx);
-    hm = histcounts(ACGCor(MatchIdx),bins)./length(MatchIdx);
-    hn = histcounts(ACGCor(NonMatchIdx),bins)./length(NonMatchIdx);
-    plot(Vector,hw,'color',[0.5 0.5 0.5])
+    Vector = [bins(1) + 0.1 / 2:0.1:bins(end) - 0.1 / 2];
+    hw = histcounts(ACGCor(WithinIdx), bins) ./ length(WithinIdx);
+    hm = histcounts(ACGCor(MatchIdx), bins) ./ length(MatchIdx);
+    hn = histcounts(ACGCor(NonMatchIdx), bins) ./ length(NonMatchIdx);
+    plot(Vector, hw, 'color', [0.5, 0.5, 0.5])
     hold on
-    plot(Vector,hm,'color',[0 0.5 0])
-    plot(Vector,hn,'color',[0 0 0])
+    plot(Vector, hm, 'color', [0, 0.5, 0])
+    plot(Vector, hn, 'color', [0, 0, 0])
     xlabel('Autocorrelogram Correlation')
     ylabel('Proportion|Group')
-    legend('i=j; within recording','matches','non-matches','Location','best')
+    legend('i=j; within recording', 'matches', 'non-matches', 'Location', 'best')
     axis square
 
     makepretty
 
-    subplot(3,3,6)
-    labels = [ones(1,numel(MatchIdx)), zeros(1,numel(NonMatchIdx))];
+    subplot(3, 3, 6)
+    labels = [ones(1, numel(MatchIdx)), zeros(1, numel(NonMatchIdx))];
     scores = [ACGCor(MatchIdx)', ACGCor(NonMatchIdx)'];
-    [X,Y,~,AUC1] = perfcurve(labels,scores,1);
-    h(1) = plot(X,Y,'color',[0 0.25 0]);
+    [X, Y, ~, AUC1] = perfcurve(labels, scores, 1);
+    h(1) = plot(X, Y, 'color', [0, 0.25, 0]);
     hold all
-    labels = [ones(1,numel(MatchIdx)), zeros(1,numel(WithinIdx))];
+    labels = [ones(1, numel(MatchIdx)), zeros(1, numel(WithinIdx))];
     scores = [ACGCor(MatchIdx)', ACGCor(WithinIdx)'];
-    [X,Y,~,AUC2] = perfcurve(labels,scores,1);
-    h(2) = plot(X,Y,'color',[0 0.5 0]);
-    labels = [ones(1,numel(WithinIdx)), zeros(1,numel(NonMatchIdx))];
+    [X, Y, ~, AUC2] = perfcurve(labels, scores, 1);
+    h(2) = plot(X, Y, 'color', [0, 0.5, 0]);
+    labels = [ones(1, numel(WithinIdx)), zeros(1, numel(NonMatchIdx))];
     scores = [ACGCor(WithinIdx)', ACGCor(NonMatchIdx)'];
-    [X,Y,~,AUC3] = perfcurve(labels,scores,1);
-    h(3) = plot(X,Y,'color',[0.25 0.25 0.25]);
+    [X, Y, ~, AUC3] = perfcurve(labels, scores, 1);
+    h(3) = plot(X, Y, 'color', [0.25, 0.25, 0.25]);
 
-    plot([0 1],[0 1],'k--')
+    plot([0, 1], [0, 1], 'k--')
     xlabel('False positive rate')
     ylabel('True positive rate')
-    legend([h(:)],'Match vs No Match','Match vs Within','Within vs No Match','Location','best')
-    title(sprintf('Autocorrelogram AUC: %.3f, %.3f, %.3f', AUC1,AUC2,AUC3))
+    legend([h(:)], 'Match vs No Match', 'Match vs Within', 'Within vs No Match', 'Location', 'best')
+    title(sprintf('Autocorrelogram AUC: %.3f, %.3f, %.3f', AUC1, AUC2, AUC3))
     makepretty
     axis square
 
     freezeColors
 
     %% Plot FR
-    subplot(3,3,7)
-    imagesc(reshape(MatchTable.FRDiff,nclus,nclus))
+    subplot(3, 3, 7)
+    imagesc(reshape(MatchTable.FRDiff, nclus, nclus))
     hold on
     colormap(gray)
     makepretty
     xlabel('Unit_i')
     ylabel('Unit_j')
     hold on
-    arrayfun(@(X) line([SessionSwitch(X) SessionSwitch(X)],get(gca,'ylim'),'color',[1 0 0]),2:length(SessionSwitch),'Uni',0)
-    arrayfun(@(X) line(get(gca,'xlim'),[SessionSwitch(X) SessionSwitch(X)],'color',[1 0 0]),2:length(SessionSwitch),'Uni',0)
+    arrayfun(@(X) line([SessionSwitch(X), SessionSwitch(X)], get(gca, 'ylim'), 'color', [1, 0, 0]), 2:length(SessionSwitch), 'Uni', 0)
+    arrayfun(@(X) line(get(gca, 'xlim'), [SessionSwitch(X), SessionSwitch(X)], 'color', [1, 0, 0]), 2:length(SessionSwitch), 'Uni', 0)
     title('Firing rate differences')
     axis square
 
-    FRDiff = reshape(MatchTable.FRDiff,nclus,nclus);
-    Subtr = repmat(diag(FRDiff),1,size(FRDiff,1));
+    FRDiff = reshape(MatchTable.FRDiff, nclus, nclus);
+    Subtr = repmat(diag(FRDiff), 1, size(FRDiff, 1));
     FRDiff = FRDiff - Subtr; % Subtract diagonalcorrelations
 
-    subplot(3,3,8)
+    subplot(3, 3, 8)
     bins = min(FRDiff(:)):0.1:5;
-    Vector = [bins(1)+0.1/2:0.1:bins(end)-0.1/2];
-    hw = histcounts(FRDiff(WithinIdx),bins)./length(WithinIdx);
-    hm = histcounts(FRDiff(MatchIdx),bins)./length(MatchIdx);
-    hn = histcounts(FRDiff(NonMatchIdx),bins)./length(NonMatchIdx);
-    plot(Vector,hw,'color',[0.5 0.5 0.5])
+    Vector = [bins(1) + 0.1 / 2:0.1:bins(end) - 0.1 / 2];
+    hw = histcounts(FRDiff(WithinIdx), bins) ./ length(WithinIdx);
+    hm = histcounts(FRDiff(MatchIdx), bins) ./ length(MatchIdx);
+    hn = histcounts(FRDiff(NonMatchIdx), bins) ./ length(NonMatchIdx);
+    plot(Vector, hw, 'color', [0.5, 0.5, 0.5])
     hold on
-    plot(Vector,hm,'color',[0 0.5 0])
-    plot(Vector,hn,'color',[0 0 0])
+    plot(Vector, hm, 'color', [0, 0.5, 0])
+    plot(Vector, hn, 'color', [0, 0, 0])
     xlabel('Firing rate differences')
     ylabel('Proportion|Group')
-    legend('i=j; within recording','matches','non-matches','Location','best')
+    legend('i=j; within recording', 'matches', 'non-matches', 'Location', 'best')
     makepretty
     axis square
 
-    subplot(3,3,9)
-    labels = [zeros(1,numel(MatchIdx)), ones(1,numel(NonMatchIdx))];
+    subplot(3, 3, 9)
+    labels = [zeros(1, numel(MatchIdx)), ones(1, numel(NonMatchIdx))];
     scores = [FRDiff(MatchIdx)', FRDiff(NonMatchIdx)'];
-    [X,Y,~,AUC1] = perfcurve(labels,scores,1);
-    h(1) = plot(X,Y,'color',[0 0.25 0]);
+    [X, Y, ~, AUC1] = perfcurve(labels, scores, 1);
+    h(1) = plot(X, Y, 'color', [0, 0.25, 0]);
     hold all
-    labels = [zeros(1,numel(MatchIdx)), ones(1,numel(WithinIdx))];
+    labels = [zeros(1, numel(MatchIdx)), ones(1, numel(WithinIdx))];
     scores = [FRDiff(MatchIdx)', FRDiff(WithinIdx)'];
-    [X,Y,~,AUC2] = perfcurve(labels,scores,1);
-    h(2) = plot(X,Y,'color',[0 0.5 0]);
-    labels = [zeros(1,numel(WithinIdx)), ones(1,numel(NonMatchIdx))];
+    [X, Y, ~, AUC2] = perfcurve(labels, scores, 1);
+    h(2) = plot(X, Y, 'color', [0, 0.5, 0]);
+    labels = [zeros(1, numel(WithinIdx)), ones(1, numel(NonMatchIdx))];
     scores = [FRDiff(WithinIdx)', FRDiff(NonMatchIdx)'];
-    [X,Y,~,AUC3] = perfcurve(labels,scores,1);
-    h(3) = plot(X,Y,'color',[0.25 0.25 0.25]);
+    [X, Y, ~, AUC3] = perfcurve(labels, scores, 1);
+    h(3) = plot(X, Y, 'color', [0.25, 0.25, 0.25]);
     axis square
 
-    plot([0 1],[0 1],'k--')
+    plot([0, 1], [0, 1], 'k--')
     xlabel('False positive rate')
     ylabel('True positive rate')
-    legend([h(:)],'Match vs No Match','Match vs Within','Within vs No Match','Location','best')
-    title(sprintf('Firing rate differences AUC: %.3f, %.3f, %.3f', AUC1,AUC2,AUC3))
+    legend([h(:)], 'Match vs No Match', 'Match vs Within', 'Within vs No Match', 'Location', 'best')
+    title(sprintf('Firing rate differences AUC: %.3f, %.3f, %.3f', AUC1, AUC2, AUC3))
     makepretty
 
     % save
-    set(gcf,'units','normalized','outerposition',[0 0 1 1])
-    saveas(gcf,fullfile(SaveDir,[addname 'FunctionalScoreSeparability.fig']))
-    saveas(gcf,fullfile(SaveDir,[addname 'FunctionalScoreSeparability.png']))
+    set(gcf, 'units', 'normalized', 'outerposition', [0, 0, 1, 1])
+    saveas(gcf, fullfile(SaveDir, [addname, 'FunctionalScoreSeparability.fig']))
+    saveas(gcf, fullfile(SaveDir, [addname, 'FunctionalScoreSeparability.png']))
 end
 return

--- a/Dependencies/Paper_Figures/QualityMetricsROCs.m
+++ b/Dependencies/Paper_Figures/QualityMetricsROCs.m
@@ -1,6 +1,6 @@
 function QualityMetricsROCs(SaveDir)
 
-TmpFile = matfile(fullfile(SaveDir,'UnitMatch.mat')); % Access saved file
+TmpFile = matfile(fullfile(SaveDir, 'UnitMatch.mat')); % Access saved file
 UMparam = TmpFile.UMparam; % Extract parameters
 UMparam.binsz = 0.01; % Binsize in time (s) for the cross-correlation fingerprint. We recommend ~2-10ms time windows
 
@@ -11,7 +11,7 @@ UniqueIDConversion = TmpFile.UniqueIDConversion;
 if UMparam.GoodUnitsOnly
     GoodId = logical(UniqueIDConversion.GoodID);
 else
-    GoodId = true(1,length(UniqueIDConversion.GoodID));
+    GoodId = true(1, length(UniqueIDConversion.GoodID));
 end
 UniqueID = UniqueIDConversion.UniqueID(GoodId);
 OriID = UniqueIDConversion.OriginalClusID(GoodId);
@@ -32,39 +32,40 @@ for recid = 1:nRec
     qMetricsPath = d.folder;
     [~, qMetric, fractionRPVs_allTauR] = bc_loadSavedMetrics(qMetricsPath);
 
-    ThisIdx = find(GoodId(recsesall==recid)); % Only take good units of this round
-    qMclusterID = qMetric.clusterID-1; %0-index
-    ThisIdx = ismember(qMclusterID,OriIDAll(ThisIdx)); % Find the same cluster IDs
+    ThisIdx = find(GoodId(recsesall == recid)); % Only take good units of this round
+    qMclusterID = qMetric.clusterID - 1; %0-index
+    ThisIdx = ismember(qMclusterID, OriIDAll(ThisIdx)); % Find the same cluster IDs
 
-    if recid==1
-        qMetricAllGoodUnits = qMetric(ThisIdx,:); % Add sessions together, only take good units
+    if recid == 1
+        qMetricAllGoodUnits = qMetric(ThisIdx, :); % Add sessions together, only take good units
     else
-        qMetricAllGoodUnits = cat(1,qMetricAllGoodUnits,qMetric(ThisIdx,:));
+        qMetricAllGoodUnits = cat(1, qMetricAllGoodUnits, qMetric(ThisIdx, :));
     end
 end
 
 %% Units that formed a match with any other unit (across recordings)
-MatchProb = reshape(MatchTable.MatchProb,nclus,nclus);
-[ridx,cidx] = find(MatchProb>UMparam.ProbabilityThreshold);
-SameUnit = ridx==cidx;
-Pairs = cat(2,ridx(~SameUnit),cidx(~SameUnit));
+MatchProb = reshape(MatchTable.MatchProb, nclus, nclus);
+[ridx, cidx] = find(MatchProb > UMparam.ProbabilityThreshold);
+SameUnit = ridx == cidx;
+Pairs = cat(2, ridx(~SameUnit), cidx(~SameUnit));
 UnitsWithAMatch = unique(Pairs(:));
 UnitsWithoutAMatch = 1:nclus;
-UnitsWithoutAMatch(ismember(UnitsWithoutAMatch,UnitsWithAMatch))=[];
-%% For every qParams, make an ROC
-figure('name','ROCs with Quality Metrics')
-for qmid = 1:size(qMetricAllGoodUnits,2)
-    subplot(ceil(sqrt(size(qMetricAllGoodUnits,2))),round(sqrt(size(qMetricAllGoodUnits,2))),qmid)
+UnitsWithoutAMatch(ismember(UnitsWithoutAMatch, UnitsWithAMatch)) = [];
 
-    labels = [ones(1,numel(UnitsWithAMatch)), zeros(1,numel(UnitsWithoutAMatch))];  
-    scores = [table2array(qMetricAllGoodUnits(UnitsWithAMatch,qmid))', table2array(qMetricAllGoodUnits(UnitsWithoutAMatch,qmid))'];
-    [X,Y,~,AUC3] = perfcurve(labels,scores,1);
-    h(3) = plot(X,Y,'color',[0.25 0.25 0.25]);
+%% For every qParams, make an ROC
+figure('name', 'ROCs with Quality Metrics')
+for qmid = 1:size(qMetricAllGoodUnits, 2)
+    subplot(ceil(sqrt(size(qMetricAllGoodUnits, 2))), round(sqrt(size(qMetricAllGoodUnits, 2))), qmid)
+
+    labels = [ones(1, numel(UnitsWithAMatch)), zeros(1, numel(UnitsWithoutAMatch))];
+    scores = [table2array(qMetricAllGoodUnits(UnitsWithAMatch, qmid))', table2array(qMetricAllGoodUnits(UnitsWithoutAMatch, qmid))'];
+    [X, Y, ~, AUC3] = perfcurve(labels, scores, 1);
+    h(3) = plot(X, Y, 'color', [0.25, 0.25, 0.25]);
     hold on
-    plot([0 1],[0 1],'k--')
+    plot([0, 1], [0, 1], 'k--')
     xlabel('False positive rate')
     ylabel('True positive rate')
-    title([qMetricAllGoodUnits.Properties.VariableNames{qmid} ', AUC = ' num2str(AUC3)])
+    title([qMetricAllGoodUnits.Properties.VariableNames{qmid}, ', AUC = ', num2str(AUC3)])
     makepretty
     axis square
     drawnow %Something to look at while ACG calculations are ongoing
@@ -73,6 +74,6 @@ end
 
 
 % save
-set(gcf,'units','normalized','outerposition',[0 0 1 1])
-saveas(gcf,fullfile(SaveDir,'QMetricsROCs.fig'))
-saveas(gcf,fullfile(SaveDir,'QMetricsROCs.png'))
+set(gcf, 'units', 'normalized', 'outerposition', [0, 0, 1, 1])
+saveas(gcf, fullfile(SaveDir, 'QMetricsROCs.fig'))
+saveas(gcf, fullfile(SaveDir, 'QMetricsROCs.png'))

--- a/Dependencies/Plotting/DrawPairsUnitMatch.m
+++ b/Dependencies/Plotting/DrawPairsUnitMatch.m
@@ -1,9 +1,9 @@
-function DrawPairsUnitMatch(SaveDir,DrawBlind)
-if nargin<2
+function DrawPairsUnitMatch(SaveDir, DrawBlind)
+if nargin < 2
     DrawBlind = 0;
 end
 Redo = 0;
-TmpFile = matfile(fullfile(SaveDir,'UnitMatch.mat')); % Access saved file
+TmpFile = matfile(fullfile(SaveDir, 'UnitMatch.mat')); % Access saved file
 UMparam = TmpFile.UMparam; % Extract parameters
 MatchTable = TmpFile.MatchTable; % Load Matchtable
 try
@@ -19,7 +19,7 @@ UniqueIDConversion = TmpFile.UniqueIDConversion;
 if UMparam.GoodUnitsOnly
     GoodId = logical(UniqueIDConversion.GoodID);
 else
-    GoodId = true(1,length(UniqueIDConversion.GoodID));
+    GoodId = true(1, length(UniqueIDConversion.GoodID));
 end
 UniqueID = UniqueIDConversion.UniqueID(GoodId);
 OriID = UniqueIDConversion.OriginalClusID(GoodId);
@@ -31,86 +31,86 @@ AllKSDir = UMparam.KSDir; %original KS Dir
 nclus = length(UniqueID);
 % Pairs redefined:
 uId = unique(UniqueID);
-Pairs = arrayfun(@(X) find(UniqueID==X),uId,'Uni',0);
-Pairs(cellfun(@length,Pairs)==1) = [];
+Pairs = arrayfun(@(X) find(UniqueID == X), uId, 'Uni', 0);
+Pairs(cellfun(@length, Pairs) == 1) = [];
 
-MatchProb = reshape(MatchTable.MatchProb,nclus,nclus);
-lowselfscores = find(diag(MatchProb)<UMparam.ProbabilityThreshold);
-for id =1:length(lowselfscores) % Add these for plotting - inspection
-    Pairs{end+1} = [lowselfscores(id) lowselfscores(id)];
+MatchProb = reshape(MatchTable.MatchProb, nclus, nclus);
+lowselfscores = find(diag(MatchProb) < UMparam.ProbabilityThreshold);
+for id = 1:length(lowselfscores) % Add these for plotting - inspection
+    Pairs{end+1} = [lowselfscores(id), lowselfscores(id)];
 end
 
-PyKSLabel = false(nclus,nclus);
-label = MatchProb>UMparam.ProbabilityThreshold;
+PyKSLabel = false(nclus, nclus);
+label = MatchProb > UMparam.ProbabilityThreshold;
 
 if UMparam.RunPyKSChronicStitched
     PairsPyKS = [];
     for uid = 1:nclus
-        pairstmp = find(OriID==OriID(uid))';
-        if length(pairstmp)>1
-            PairsPyKS = cat(1,PairsPyKS,pairstmp);
+        pairstmp = find(OriID == OriID(uid))';
+        if length(pairstmp) > 1
+            PairsPyKS = cat(1, PairsPyKS, pairstmp);
         end
     end
 
-    for pid = 1:size(PairsPyKS,1)
-        PyKSLabel(PairsPyKS(pid,1),PairsPyKS(pid,2)) = true;
-        PyKSLabel(PairsPyKS(pid,2),PairsPyKS(pid,1)) = true;
+    for pid = 1:size(PairsPyKS, 1)
+        PyKSLabel(PairsPyKS(pid, 1), PairsPyKS(pid, 2)) = true;
+        PyKSLabel(PairsPyKS(pid, 2), PairsPyKS(pid, 1)) = true;
     end
     PyKSLabel(logical(eye(size(PyKSLabel)))) = true;
-    [r,c] = find(label==0 & PyKSLabel==1);
-    PairsPKS = cat(2,r,c);
-    PairsPKS(r==c,:) = [];
-    PairsPKS = sort(PairsPKS,2,'ascend');
-    PairsPKS = unique(PairsPKS,'stable','rows');
-    Pairs = cat(2,Pairs,arrayfun(@(X) PairsPKS(X,:),1:length(PairsPKS),'Uni',0));% Add these for plotting - inspection
+    [r, c] = find(label == 0 & PyKSLabel == 1);
+    PairsPKS = cat(2, r, c);
+    PairsPKS(r == c, :) = [];
+    PairsPKS = sort(PairsPKS, 2, 'ascend');
+    PairsPKS = unique(PairsPKS, 'stable', 'rows');
+    Pairs = cat(2, Pairs, arrayfun(@(X) PairsPKS(X, :), 1:length(PairsPKS), 'Uni', 0)); % Add these for plotting - inspection
 end
 
 if DrawBlind
     % Keep length 2 for each pair
-    tmptbl = dir(fullfile(UMparam.SaveDir,'BlindFigures','BlindTable.mat'));
+    tmptbl = dir(fullfile(UMparam.SaveDir, 'BlindFigures', 'BlindTable.mat'));
 
-    if ~Redo &&  ~isempty(tmptbl)
-        tmptbl = load(fullfile(tmptbl(1).folder,tmptbl(1).name));
-        Pair1 = cell2mat(arrayfun(@(X) find(ismember(OriID,tmptbl.tbl.ClusID1(X)) & ismember(recses,tmptbl.tbl.RecID1(X))),1:height(tmptbl.tbl),'Uni',0));
-        Pair2 = cell2mat(arrayfun(@(X) find(ismember(OriID,tmptbl.tbl.ClusID2(X)) & ismember(recses,tmptbl.tbl.RecID2(X))),1:height(tmptbl.tbl),'Uni',0));
-        Pairs = arrayfun(@(X) [Pair1(X) Pair2(X)],1:length(Pair1),'Uni',0);
+    if ~Redo && ~isempty(tmptbl)
+        tmptbl = load(fullfile(tmptbl(1).folder, tmptbl(1).name));
+        Pair1 = cell2mat(arrayfun(@(X) find(ismember(OriID, tmptbl.tbl.ClusID1(X)) & ismember(recses, tmptbl.tbl.RecID1(X))), 1:height(tmptbl.tbl), 'Uni', 0));
+        Pair2 = cell2mat(arrayfun(@(X) find(ismember(OriID, tmptbl.tbl.ClusID2(X)) & ismember(recses, tmptbl.tbl.RecID2(X))), 1:height(tmptbl.tbl), 'Uni', 0));
+        Pairs = arrayfun(@(X) [Pair1(X), Pair2(X)], 1:length(Pair1), 'Uni', 0);
     else
-        Pairs = cellfun(@(X) X(1:2),Pairs,'Uni',0);
+        Pairs = cellfun(@(X) X(1:2), Pairs, 'Uni', 0);
         % Need to add some low probabilities, but around same location
-        EucledianDistance = reshape(MatchTable.EucledianDistance,nclus,nclus);
-        [r,c] = find(label==0 & PyKSLabel == 0 & EucledianDistance < UMparam.NeighbourDist);
-        LowProb = cat(2,r,c);
-        LowProb(r==c,:) = [];
-        LowProb = sort(LowProb,2,'ascend');
-        LowProb = unique(LowProb,'stable','rows');
+        EucledianDistance = reshape(MatchTable.EucledianDistance, nclus, nclus);
+        [r, c] = find(label == 0 & PyKSLabel == 0 & EucledianDistance < UMparam.NeighbourDist);
+        LowProb = cat(2, r, c);
+        LowProb(r == c, :) = [];
+        LowProb = sort(LowProb, 2, 'ascend');
+        LowProb = unique(LowProb, 'stable', 'rows');
         % Match number of pairs for equal set
         npairs = length(Pairs);
-        LowProb = LowProb(randsample(length(LowProb),npairs,0),:);
-        Pairs = cat(2,Pairs,arrayfun(@(X) LowProb(X,:),1:length(LowProb),'Uni',0));
+        LowProb = LowProb(randsample(length(LowProb), npairs, 0), :);
+        Pairs = cat(2, Pairs, arrayfun(@(X) LowProb(X, :), 1:length(LowProb), 'Uni', 0));
 
         % add some diagonal (i=j within)
-        addIisJ = randsample(nclus,round(0.1*npairs),0);
-        addIisJ = repmat(addIisJ,1,2);
-        Pairs = cat(2,Pairs,arrayfun(@(X) addIisJ(X,:),1:length(addIisJ),'Uni',0));
+        addIisJ = randsample(nclus, round(0.1*npairs), 0);
+        addIisJ = repmat(addIisJ, 1, 2);
+        Pairs = cat(2, Pairs, arrayfun(@(X) addIisJ(X, :), 1:length(addIisJ), 'Uni', 0));
         % Randomly shuffle Pairs so we don't have matches grouped together and
         % different order for different runs
-        Pairs = Pairs(randsample(length(Pairs),length(Pairs),0));
+        Pairs = Pairs(randsample(length(Pairs), length(Pairs), 0));
 
     end
 
-    if size(Pairs,2)>UMparam.drawmax
-        DrawPairs = randsample(1:size(Pairs,2),UMparam.drawmax,'false');
+    if size(Pairs, 2) > UMparam.drawmax
+        DrawPairs = randsample(1:size(Pairs, 2), UMparam.drawmax, 'false');
     else
-        DrawPairs = 1:size(Pairs,2);
+        DrawPairs = 1:size(Pairs, 2);
     end
-    PlotTheseUnits_UM_Blind(Pairs(DrawPairs),MatchTable,UniqueIDConversion,WaveformInfo,AllSessionCorrelations,UMparam)
+    PlotTheseUnits_UM_Blind(Pairs(DrawPairs), MatchTable, UniqueIDConversion, WaveformInfo, AllSessionCorrelations, UMparam)
 else
-    if size(Pairs,2)>UMparam.drawmax
-        DrawPairs = randsample(1:size(Pairs,2),UMparam.drawmax,'false');
+    if size(Pairs, 2) > UMparam.drawmax
+        DrawPairs = randsample(1:size(Pairs, 2), UMparam.drawmax, 'false');
     else
-        DrawPairs = 1:size(Pairs,2);
+        DrawPairs = 1:size(Pairs, 2);
     end
-    PlotTheseUnits_UM(Pairs(DrawPairs),MatchTable,UniqueIDConversion,WaveformInfo,AllSessionCorrelations,UMparam)
+    PlotTheseUnits_UM(Pairs(DrawPairs), MatchTable, UniqueIDConversion, WaveformInfo, AllSessionCorrelations, UMparam)
 end
 
 

--- a/Dependencies/UnitMatchPipeline/CalculateDuration.m
+++ b/Dependencies/UnitMatchPipeline/CalculateDuration.m
@@ -1,13 +1,22 @@
-function DataSizeParam = CalculateDuration(Dir2Use)
+function DataSizeParam = CalculateDuration(Dir2Use, metaLocation)
 % Dir2Use = 'H:\Ongoing\EB019\'
 tmp = dir(fullfile(Dir2Use,'UnitMatch','UnitMatch.mat'));
 
 tmp = load(fullfile(tmp.folder,tmp.name));
 TotalDur = 0;
 TotalBytes = 0;
-for id = 1:length(tmp.UMparam.AllRawPaths)
-
-    meta = ReadMeta2(tmp.UMparam.AllRawPaths(id).folder);
+if exist("metaLocation")
+    meta_path = metaLocation;
+else
+    meta_path = tmp.UMparam.AllRawPaths;
+end
+for id = 1:length(meta_path)
+    if isstruct(meta_path(id))
+        meta = ReadMeta2(meta_path(id).folder);
+    else
+        meta_folder = dir(meta_path{id});
+        meta = ReadMeta2(meta_folder.folder);
+    end
     TotalDur = TotalDur+str2num(meta.fileTimeSecs);
     TotalBytes = TotalBytes + str2num(meta.fileSizeBytes);
 end

--- a/Dependencies/UnitMatchPipeline/EvaluatingUnitMatch.m
+++ b/Dependencies/UnitMatchPipeline/EvaluatingUnitMatch.m
@@ -1,16 +1,17 @@
 function EvaluatingUnitMatch(DirToEvaluate)
+
 %% Evaluating UnitMatch
 % DirToEvaluate = 'H:\MatchingUnits\Output\AL032\UnitMatch';
 stepsize = 0.01;
 % Load UnitMatch Output
-Output2Evaluate = dir(fullfile(DirToEvaluate,'UnitMatch.mat'));
-Output2Evaluate = matfile(fullfile(Output2Evaluate.folder,Output2Evaluate.name));
-    UMparam = Output2Evaluate.UMparam;
+Output2Evaluate = dir(fullfile(DirToEvaluate, 'UnitMatch.mat'));
+Output2Evaluate = matfile(fullfile(Output2Evaluate.folder, Output2Evaluate.name));
+UMparam = Output2Evaluate.UMparam;
 
 ShowScores = 0;
-for id = 1%:2 % Loop: first use model that was used, then see if standard model would work better
-    if id==1
-        Model2Evaluate = dir(fullfile(DirToEvaluate,'UnitMatchModel.mat'));
+for id = 1 %:2 % Loop: first use model that was used, then see if standard model would work better
+    if id == 1
+        Model2Evaluate = dir(fullfile(DirToEvaluate, 'UnitMatchModel.mat'));
         disp('Evaluating the model as it was ran by user')
         extraname = 'Used Model';
     else
@@ -18,10 +19,10 @@ for id = 1%:2 % Loop: first use model that was used, then see if standard model 
         % Compare to standard model
         P = mfilename('fullpath');
         P = fileparts(P);
-        Model2Evaluate = dir(fullfile(P,'UnitMatchModel.mat'));
+        Model2Evaluate = dir(fullfile(P, 'UnitMatchModel.mat'));
         extraname = 'Standard Model';
     end
-    Model2Evaluate = matfile(fullfile(Model2Evaluate.folder,Model2Evaluate.name));
+    Model2Evaluate = matfile(fullfile(Model2Evaluate.folder, Model2Evaluate.name));
 
     % Extract MatchTable
     MatchTable = Output2Evaluate.MatchTable;
@@ -30,25 +31,24 @@ for id = 1%:2 % Loop: first use model that was used, then see if standard model 
     ndays = length(unique(UniqueIDConversion.recsesAll));
     % Extract Model
     BestMdl = Model2Evaluate.BestMdl;
-    if ~isfield(BestMdl,'Priors')
-        priorMatch = 1-((nclus+nclus.*sqrt(ndays-1)*UMparam.ExpectMatches)./(nclus*nclus)); %Punish multiple days (unlikely to find as many matches after a few days)
-        BestMdl.Priors = [priorMatch 1-priorMatch];
+    if ~isfield(BestMdl, 'Priors')
+        priorMatch = 1 - ((nclus + nclus .* sqrt(ndays-1) * UMparam.ExpectMatches) ./ (nclus * nclus)); %Punish multiple days (unlikely to find as many matches after a few days)
+        BestMdl.Priors = [priorMatch, 1 - priorMatch];
     end
     if id == 1
         VariableNames = BestMdl.VariableNames;
     end
-    VariableIndex = find(ismember(BestMdl.VariableNames,VariableNames));
+    VariableIndex = find(ismember(BestMdl.VariableNames, VariableNames));
     nRows = ceil(sqrt(length(VariableNames)+1));
     nCols = round(sqrt(length(VariableNames)+1));
 
-
     %% Assuming UnitMatch worked, how many units were tracked?
-    if id==1
+    if id == 1
         if UMparam.GoodUnitsOnly
             if UMparam.GoodUnitsOnly
                 GoodId = logical(UniqueIDConversion.GoodID);
             else
-                GoodId = true(1,length(UniqueIDConversion.GoodID));
+                GoodId = true(1, length(UniqueIDConversion.GoodID));
             end
             UniqueID = UniqueIDConversion.UniqueID(GoodId);
             OriID = UniqueIDConversion.OriginalClusID(GoodId);
@@ -56,41 +56,42 @@ for id = 1%:2 % Loop: first use model that was used, then see if standard model 
             recses = UniqueIDConversion.recsesAll(GoodId);
             recsesall = UniqueIDConversion.recsesAll;
         end
-        TrackingPerformance = nan(3,0); % Difference between recording number, % Tracked units %maximum possibility
-        MatchProb = reshape(MatchTable.MatchProb,nclus,nclus);
+        TrackingPerformance = nan(3, 0); % Difference between recording number, % Tracked units %maximum possibility
+        MatchProb = reshape(MatchTable.MatchProb, nclus, nclus);
         for did1 = 1:ndays
             for did2 = 1:ndays
-                if did2<=did1
+                if did2 <= did1
                     continue
                 end
-                thesedaysidx = find(ismember(recses,[did1,did2]));
+                thesedaysidx = find(ismember(recses, [did1, did2]));
                 % can possibly only track these many units:
-                nMax = min([sum(recses(thesedaysidx)==did1) sum(recses(thesedaysidx)==did2)]);      
+                nMax = min([sum(recses(thesedaysidx) == did1), sum(recses(thesedaysidx) == did2)]);
                 % only matches across days
                 recsesthesedays = recses(thesedaysidx);
-                nMatches = sum(arrayfun(@(X) length(unique(recsesthesedays(UniqueID(thesedaysidx)==X)))>1,unique(UniqueID(thesedaysidx))));              
-                TrackingPerformance = cat(2,TrackingPerformance,[did2-did1,nMatches,nMax]');
+                nMatches = sum(arrayfun(@(X) length(unique(recsesthesedays(UniqueID(thesedaysidx) == X))) > 1, unique(UniqueID(thesedaysidx))));
+                TrackingPerformance = cat(2, TrackingPerformance, [did2 - did1, nMatches, nMax]');
             end
         end
 
-        figure('name',['TrackingPerformance ' UMparam.SaveDir])
-        subplot(1,2,1)
-        scatter(TrackingPerformance(3,:),TrackingPerformance(2,:),20,[0 0 0],'filled')
+        figure('name', ['TrackingPerformance ', UMparam.SaveDir])
+        subplot(1, 2, 1)
+        scatter(TrackingPerformance(3, :), TrackingPerformance(2, :), 20, [0, 0, 0], 'filled')
         hold on
-        xlims = get(gca,'xlim');
-        line([0 max(xlims)],[0 max(xlims)],'color',[0 0 0])
+        xlims = get(gca, 'xlim');
+        line([0, max(xlims)], [0, max(xlims)], 'color', [0, 0, 0])
         xlabel('Number Units Available')
         ylabel('Number Units Tracked')
 
-        subplot(1,2,2)
-        scatter(TrackingPerformance(1,:),TrackingPerformance(2,:)./TrackingPerformance(3,:),20,[0 0 0],'filled')
+        subplot(1, 2, 2)
+        scatter(TrackingPerformance(1, :), TrackingPerformance(2, :)./TrackingPerformance(3, :), 20, [0, 0, 0], 'filled')
         xlabel('\Delta Recordings')
         ylabel('Proportion tracked cells')
     end
+
     %% 'Ground truth' (or as best as we can): Take the set where ID1 == ID2 (False Negatives)
     if UMparam.RunPyKSChronicStitched
         disp('Across and within recording cross-validation: PyKS was ran stitched')
-        GTMatchidx = find(MatchTable.ID1 == MatchTable.ID2);% & MatchTable.RecSes1 ~= MatchTable.RecSes2);
+        GTMatchidx = find(MatchTable.ID1 == MatchTable.ID2); % & MatchTable.RecSes1 ~= MatchTable.RecSes2);
         GTNonMatch = find(MatchTable.ID1 ~= MatchTable.ID2);
     else
         disp('Within recording cross-validation: PyKS was ran on individual sessions')
@@ -100,64 +101,64 @@ for id = 1%:2 % Loop: first use model that was used, then see if standard model 
 
     % What is the match probability of
     Edges = [0:stepsize:1];
-    Vect = stepsize/2:stepsize:1-stepsize/2;
-    hM = histcounts(MatchTable.MatchProb(GTMatchidx),Edges)./length(GTMatchidx);
-    hNM = histcounts(MatchTable.MatchProb(GTNonMatch),Edges)./length(GTNonMatch);
+    Vect = stepsize / 2:stepsize:1 - stepsize / 2;
+    hM = histcounts(MatchTable.MatchProb(GTMatchidx), Edges) ./ length(GTMatchidx);
+    hNM = histcounts(MatchTable.MatchProb(GTNonMatch), Edges) ./ length(GTNonMatch);
 
     if ShowScores
-        figure('name',['Scores ' extraname ' False Negatives']);
-        subplot(nRows,nCols,1)
-        plot(Vect,hNM,'b-')
+        figure('name', ['Scores ', extraname, ' False Negatives']);
+        subplot(nRows, nCols, 1)
+        plot(Vect, hNM, 'b-')
         hold on
-        plot(Vect,hM,'r-')
-        legend('KS not same unit','KS Same unit')
+        plot(Vect, hM, 'r-')
+        legend('KS not same unit', 'KS Same unit')
         title('Match probability of KS identified clusters')
         ylabel('nSamples')
         makepretty
 
         % Now show distributions for the other parameters
         for vid = 1:length(VariableNames)
-            eval(['hM = histcounts(MatchTable.'  VariableNames{vid} '(GTMatchidx),Edges)./length(GTMatchidx);'])
-            eval(['hNM = histcounts(MatchTable.'  VariableNames{vid} '(GTNonMatch),Edges)./length(GTNonMatch);'])
-            subplot(nRows,nCols,1+vid)
-            plot(Vect,hNM,'b-')
+            eval(['hM = histcounts(MatchTable.', VariableNames{vid}, '(GTMatchidx),Edges)./length(GTMatchidx);'])
+            eval(['hNM = histcounts(MatchTable.', VariableNames{vid}, '(GTNonMatch),Edges)./length(GTNonMatch);'])
+            subplot(nRows, nCols, 1+vid)
+            plot(Vect, hNM, 'b-')
             hold on
-            plot(Vect,hM,'r-')
-            title(['Score Distribution ' VariableNames{vid}])
+            plot(Vect, hM, 'r-')
+            title(['Score Distribution ', VariableNames{vid}])
             ylabel('nSamples')
             makepretty
         end
     end
     % Leave-One-Out Analysis; would we have performed better when we left out one of the variables?
-    figure('name',['Leave Out Analysis ' extraname])
-    if id==1
-        FN = nan(length(VariableNames)+1,2); %False negatives
+    figure('name', ['Leave Out Analysis ', extraname])
+    if id == 1
+        FN = nan(length(VariableNames)+1, 2); %False negatives
         FP = FN; % False positives
-        FalseNegativeChanges = nan(2,length(VariableNames)+1);
-        FalsePositiveChanges = nan(2,length(VariableNames)+1);
+        FalseNegativeChanges = nan(2, length(VariableNames)+1);
+        FalsePositiveChanges = nan(2, length(VariableNames)+1);
     end
 
-    for vid = 1:length(VariableNames)+1
+    for vid = 1:length(VariableNames) + 1
         VarNameSet = VariableNames;
-        if vid>1
+        if vid > 1
             VarNameSet(vid-1) = []; % Leave this one out
         end
         % Re-run model
-        Tbl = MatchTable(:,ismember(MatchTable.Properties.VariableNames,VarNameSet));
-        [Fakelabel, LeaveOutProb, performance] = ApplyNaiveBayes(Tbl,BestMdl.Parameterkernels(:,ismember(BestMdl.VariableNames,VarNameSet),:),[0,1],BestMdl.Priors);
+        Tbl = MatchTable(:, ismember(MatchTable.Properties.VariableNames, VarNameSet));
+        [Fakelabel, LeaveOutProb, performance] = ApplyNaiveBayes(Tbl, BestMdl.Parameterkernels(:, ismember(BestMdl.VariableNames, VarNameSet), :), [0, 1], BestMdl.Priors);
 
         % Were these neurons assigned as final matches?
-        FN(vid,id) = 1-(sum(Fakelabel(GTMatchidx))./length(GTMatchidx));
-        if vid==1
-            FalseNegativeChanges(id,vid) = FN(vid,id) - FN(1,1); % Negative is better
+        FN(vid, id) = 1 - (sum(Fakelabel(GTMatchidx)) ./ length(GTMatchidx));
+        if vid == 1
+            FalseNegativeChanges(id, vid) = FN(vid, id) - FN(1, 1); % Negative is better
         else
-            FalseNegativeChanges(id,vid) = FN(vid,id) - FN(1,id);
+            FalseNegativeChanges(id, vid) = FN(vid, id) - FN(1, id);
         end
-        FP(vid,id) = sum(Fakelabel(GTNonMatch))./length(GTNonMatch);
-        if vid==1
-            FalsePositiveChanges(id,vid) = FP(vid,id) - FP(1,1);
+        FP(vid, id) = sum(Fakelabel(GTNonMatch)) ./ length(GTNonMatch);
+        if vid == 1
+            FalsePositiveChanges(id, vid) = FP(vid, id) - FP(1, 1);
         else
-            FalsePositiveChanges(id,vid) = FP(vid,id) - FP(1,id);
+            FalsePositiveChanges(id, vid) = FP(vid, id) - FP(1, id);
         end
         %         if vid==1
         %             disp(['Full model UnitMatch identified ' num2str(round(FoundAsMatch(vid)*1000)./10) '% of Kilosort single units as such'])
@@ -166,18 +167,18 @@ for id = 1%:2 % Loop: first use model that was used, then see if standard model 
         %         end
 
         % What is the match probability of
-        hM = histcounts(LeaveOutProb(GTMatchidx,2),Edges)./length(GTMatchidx);
-        hNM = histcounts(LeaveOutProb(GTNonMatch,2),Edges)./length(GTNonMatch);
+        hM = histcounts(LeaveOutProb(GTMatchidx, 2), Edges) ./ length(GTMatchidx);
+        hNM = histcounts(LeaveOutProb(GTNonMatch, 2), Edges) ./ length(GTNonMatch);
 
-        subplot(nRows,nCols,vid)
-        plot(Vect,hNM,'b-')
+        subplot(nRows, nCols, vid)
+        plot(Vect, hNM, 'b-')
         hold on
-        plot(Vect,hM,'r-')
-        if vid==1
-            title(['Full model: FN=' num2str(round(FN(vid,id)*1000)./10) '%, FP=' num2str(round(FP(vid,id)*1000)./10) '%'])
-            legend('Not same (KS)','Same (KS)')
+        plot(Vect, hM, 'r-')
+        if vid == 1
+            title(['Full model: FN=', num2str(round(FN(vid, id)*1000)./10), '%, FP=', num2str(round(FP(vid, id)*1000)./10), '%'])
+            legend('Not same (KS)', 'Same (KS)')
         else
-            title(['wo ' VariableNames{vid-1} ': FN=' num2str(round(FN(vid,id)*1000)./10) '%, PF=' num2str(round(FP(vid,id)*1000)./10) '%'])
+            title(['wo ', VariableNames{vid-1}, ': FN=', num2str(round(FN(vid, id)*1000)./10), '%, PF=', num2str(round(FP(vid, id)*1000)./10), '%'])
         end
         ylabel('nSamples')
         xlabel('p|Match')
@@ -185,14 +186,15 @@ for id = 1%:2 % Loop: first use model that was used, then see if standard model 
 
     end
     linkaxes
-  
+
 end
+
 %% Results:
-disp(['False negative rate: '  num2str(round(FN(1,1)*1000)/10) '%'])
-disp(['False positive rate: '  num2str(round(FP(1,1)*1000)/10) '%'])
+disp(['False negative rate: ', num2str(round(FN(1, 1)*1000)/10), '%'])
+disp(['False positive rate: ', num2str(round(FP(1, 1)*1000)/10), '%'])
 
 %% Some Advise:
-if FalseNegativeChanges(2,1)<FalseNegativeChanges(1,1) & FalsePositiveChanges(2,1)<FalsePositiveChanges(1,1)
+if FalseNegativeChanges(2, 1) < FalseNegativeChanges(1, 1) & FalsePositiveChanges(2, 1) < FalsePositiveChanges(1, 1)
     disp('We advise to use the standard model on this data:')
     disp('PrepareClusInfoparams.ApplyExistingBayesModel = 1');
     id2take = 2;
@@ -200,42 +202,42 @@ else
     disp('We advise to use the model you just used on this data:')
     id2take = 1;
 end
-if any((FalseNegativeChanges(id2take,2:end)<0 & FalsePositiveChanges(id2take,2:end)<0))
+if any((FalseNegativeChanges(id2take, 2:end) < 0 & FalsePositiveChanges(id2take, 2:end) < 0))
     disp(['To optimize detection, consider taking out:'])
-    VariableNames((FalseNegativeChanges(id2take,2:end)>0 & FalsePositiveChanges(id2take,2:end)<0))
+    VariableNames((FalseNegativeChanges(id2take, 2:end) > 0 & FalsePositiveChanges(id2take, 2:end) < 0))
 
     disp(['So please try running the model with: PrepareClusInfoparams.Scores2Include = '])
-    VariableNames(~(FalseNegativeChanges(id2take,2:end)>0 & FalsePositiveChanges(id2take,2:end)<0))
+    VariableNames(~(FalseNegativeChanges(id2take, 2:end) > 0 & FalsePositiveChanges(id2take, 2:end) < 0))
 else
     disp('This parameter set is probably the best')
 end
 
 %% AUC
-if exist(fullfile(DirToEvaluate,'AUC.mat'))
-load(fullfile(DirToEvaluate,'AUC.mat'));
-AUC = AUCStruct.AUC;
-ParamNames = AUCStruct.ParamNames(~isnan(AUC));
-AUC = AUC(~isnan(AUC));
+if exist(fullfile(DirToEvaluate, 'AUC.mat'))
+    load(fullfile(DirToEvaluate, 'AUC.mat'));
+    AUC = AUCStruct.AUC;
+    ParamNames = AUCStruct.ParamNames(~isnan(AUC));
+    AUC = AUC(~isnan(AUC));
 
-figure('name','AUC versus FN Change')
-subplot(1,2,1)
-scatter(AUC(cellfun(@(X) find(ismember(ParamNames,X)),VariableNames)),FN(2:end,1),25,[0 0 0],'filled');
-xlabel('AUC')
-ylabel('Leave-out FN (%)')
-title('False Negatives')
-makepretty
+    figure('name', 'AUC versus FN Change')
+    subplot(1, 2, 1)
+    scatter(AUC(cellfun(@(X) find(ismember(ParamNames, X)), VariableNames)), FN(2:end, 1), 25, [0, 0, 0], 'filled');
+    xlabel('AUC')
+    ylabel('Leave-out FN (%)')
+    title('False Negatives')
+    makepretty
 
-subplot(1,2,2)
-scatter(AUC(cellfun(@(X) find(ismember(ParamNames,X)),VariableNames)),FP(2:end,1),25,[0 0 0],'filled');
-xlabel('AUC')
-ylabel('Leave-out FP (%)')
-title('False Positives')
-makepretty
+    subplot(1, 2, 2)
+    scatter(AUC(cellfun(@(X) find(ismember(ParamNames, X)), VariableNames)), FP(2:end, 1), 25, [0, 0, 0], 'filled');
+    xlabel('AUC')
+    ylabel('Leave-out FP (%)')
+    title('False Positives')
+    makepretty
 
-idx = AUC(~ismember(ParamNames,VariableNames))>min(AUC(ismember(ParamNames,VariableNames)));
-[~,sortid] = sort(AUC,'descend');
-disp('AUC order:')
-ParamNames(sortid)
-AUC(sortid)
+    idx = AUC(~ismember(ParamNames, VariableNames)) > min(AUC(ismember(ParamNames, VariableNames)));
+    [~, sortid] = sort(AUC, 'descend');
+    disp('AUC order:')
+    ParamNames(sortid)
+    AUC(sortid)
 end
 return

--- a/Dependencies/UnitMatchPipeline/RunUnitMatch.m
+++ b/Dependencies/UnitMatchPipeline/RunUnitMatch.m
@@ -1,31 +1,32 @@
-function UMparam = RunUnitMatch(AllKiloSortPaths,Params)
+function [UMparam, UniqueIDConversion, MatchTable, WaveformInfo] = RunUnitMatch(AllKiloSortPaths, Params, ephys_dirs)
+
 %% Here we're going to actually load in all the sessions requested - only clusinfo to save memory for unitmatch
-clusinfo = cell(1,length(AllKiloSortPaths));
-addthis=0;
-for subsesid=1:length(AllKiloSortPaths)
-    if isempty(dir(fullfile(AllKiloSortPaths{subsesid},'*.npy')))
+clusinfo = cell(1, length(AllKiloSortPaths));
+addthis = 0;
+for subsesid = 1:length(AllKiloSortPaths)
+    if isempty(dir(fullfile(AllKiloSortPaths{subsesid}, '*.npy')))
         continue
     end
 
-    disp(['Loading clusinfo for ' AllKiloSortPaths{subsesid}])
-    tmp = matfile(fullfile(AllKiloSortPaths{subsesid},'PreparedData.mat'));
+    disp(['Loading clusinfo for ', AllKiloSortPaths{subsesid}])
+    tmp = matfile(fullfile(AllKiloSortPaths{subsesid}, 'PreparedData.mat'));
     clusinfo{subsesid} = tmp.clusinfo;
 
     % Replace recsesid with subsesid
-    clusinfo{subsesid}.RecSesID = clusinfo{subsesid}.RecSesID+addthis;
-    addthis=max(clusinfo{subsesid}.RecSesID);
+    clusinfo{subsesid}.RecSesID = clusinfo{subsesid}.RecSesID + addthis;
+    addthis = max(clusinfo{subsesid}.RecSesID);
 end
 
 % Add all cluster information in one 'cluster' struct - can be used for further analysis
 clusinfo = [clusinfo{:}];
 clusinfoNew = struct;
 fields = fieldnames(clusinfo(1));
-for fieldid=1:length(fields)
+for fieldid = 1:length(fields)
     try
-        eval(['clusinfoNew.' fields{fieldid} '= cat(1,clusinfo(:).' fields{fieldid} ');'])
+        eval(['clusinfoNew.', fields{fieldid}, '= cat(1,clusinfo(:).', fields{fieldid}, ');'])
     catch ME
         try
-            eval(['clusinfoNew.' fields{fieldid} '= cat(2,clusinfo(:).' fields{fieldid} ');'])
+            eval(['clusinfoNew.', fields{fieldid}, '= cat(2,clusinfo(:).', fields{fieldid}, ');'])
         catch ME
             keyboard
         end
@@ -39,24 +40,29 @@ clear clusinfoNew
 if Params.RunQualityMetrics
     paramBC = bc_qualityParamValuesForUnitMatch;
     UMparam.sampleamount = paramBC.nRawSpikesToExtract; %500; % Nr. waveforms to include
-    UMparam.spikeWidth =paramBC.spikeWidth; %82; % in sample space (time)
+    UMparam.spikeWidth = paramBC.spikeWidth; %82; % in sample space (time)
 else
-    UMparam.sampleamount = 1000; % 
+    UMparam.sampleamount = 1000; %
     UMparam.spikeWidth = 82; %82; % in sample space (time)
 end
 
 UMparam.RunPyKSChronicStitched = Params.RunPyKSChronicStitched;
-UMparam.SaveDir = fullfile(Params.SaveDir,'UnitMatch');
+UMparam.SaveDir = fullfile(Params.SaveDir, 'UnitMatch');
 if ~isdir(UMparam.SaveDir)
     mkdir(UMparam.SaveDir)
 end
-UMparam.ACGbinSize =  0.001;%paramBC.ACGbinSize;
-UMparam.ACGduration = 1;%paramBC.ACGduration;
+UMparam.ACGbinSize = 0.001; %paramBC.ACGbinSize;
+UMparam.ACGduration = 1; %paramBC.ACGduration;
 UMparam.UseBombCelRawWav = Params.RunQualityMetrics; % 1 by default
 UMparam.KSDir = AllKiloSortPaths;
 UMparam.channelpos = Params.AllChannelPos;
 UMparam.AllRawPaths = Params.RawDataPaths;
-UMparam.AllDecompPaths = arrayfun(@(X) fullfile(Params.tmpdatafolder,strrep(Params.RawDataPaths(X).name,'cbin','bin')),1:length(Params.RawDataPaths),'Uni',0);
+if isstruct(Params.RawDataPaths)
+    UMparam.AllDecompPaths = arrayfun(@(X) fullfile(Params.tmpdatafolder, strrep(Params.RawDataPaths(X).name, 'cbin', 'bin')), 1:length(Params.RawDataPaths), 'Uni', 0);
+else
+    allDecompPaths_dirs = arrayfun(@(X) dir(Params.RawDataPaths{X}), 1:length(Params.RawDataPaths), 'Uni', 0);
+    UMparam.AllDecompPaths = arrayfun(@(X) fullfile(Params.tmpdatafolder, strrep(allDecompPaths_dirs{X}.name, 'cbin', 'bin')), 1:length(allDecompPaths_dirs), 'Uni', 0);
+end
 UMparam.RedoExtraction = 0; % Only necessary if KS was redone!
 UMparam.ProbabilityThreshold = 0.5; %Increase a bit for being more strict
 UMparam.binsize = Params.binsz;
@@ -65,38 +71,42 @@ UMparam.ApplyExistingBayesModel = Params.ApplyExistingBayesModel; %If 1, use pro
 UMparam.MakePlotsOfPairs = Params.MakePlotsOfPairs; % Plot all pairs
 UMparam.AssignUniqueID = Params.AssignUniqueID; %Assign Unique ID
 UMparam.GoodUnitsOnly = Params.GoodUnitsOnly;
-if isfield(Params,'RecType') && strcmpi(Params.RecType,'Acute')
+if isfield(Params, 'RecType') && strcmpi(Params.RecType, 'Acute')
     UMparam.ExpectMatches = 0; %We do actually not expect any matches. Change prior accordingly
 else
     UMparam.ExpectMatches = 1;
 end
 if Params.UnitMatch
-    UnitMatchExist = dir(fullfile(UMparam.SaveDir,'UnitMatch.mat'));
+    UnitMatchExist = dir(fullfile(UMparam.SaveDir, 'UnitMatch.mat'));
     if ~isempty(UnitMatchExist) && ~Params.RedoUnitMatch
-        load(fullfile(UMparam.SaveDir,'UnitMatch.mat'))
+        load(fullfile(UMparam.SaveDir, 'UnitMatch.mat'))
         clusinfo.UniqueID = UniqueIDConversion.UniqueID;
         clusinfo.MatchTable = MatchTable;
     else
         % Need to decompress if decompression wasn't done yet
         for id = 1:length(Params.RawDataPaths)
             ephysap_tmp = [];
-            ephysap_path = fullfile(Params.RawDataPaths(id).folder,Params.RawDataPaths(id).name);
+            if isstruct(Params.RawDataPaths)
+                ephysap_path = fullfile(Params.RawDataPaths(id).folder, Params.RawDataPaths(id).name);
+            else
+                ephysap_path = fullfile(Params.RawDataPaths{id});
+            end
             if (isempty(UnitMatchExist) || Params.RedoUnitMatch) && ~Params.DecompressionFlag && ~UMparam.UseBombCelRawWav
                 % First check if we want to use python for compressed data. If not, uncompress data first
-                if any(strfind(Params.RawDataPaths(id).name,'cbin')) && Params.DecompressLocal
-                    if ~exist(fullfile(Params.tmpdatafolder,strrep(Params.RawDataPaths(id).name,'cbin','bin')))
+                if any(strfind(Params.RawDataPaths(id).name, 'cbin')) && Params.DecompressLocal
+                    if ~exist(fullfile(Params.tmpdatafolder, strrep(Params.RawDataPaths(id).name, 'cbin', 'bin')))
                         disp('This is compressed data and we do not want to use Python integration... uncompress temporarily')
 
-                        decompDataFile = bc_extractCbinData(fullfile(Params.RawDataPaths(id).folder,Params.RawDataPaths(id).name),...
-                            [], [], 0, fullfile(Params.tmpdatafolder,strrep(Params.RawDataPaths(id).name,'cbin','bin')));
+                        decompDataFile = bc_extractCbinData(fullfile(Params.RawDataPaths(id).folder, Params.RawDataPaths(id).name), ...
+                            [], [], 0, fullfile(Params.tmpdatafolder, strrep(Params.RawDataPaths(id).name, 'cbin', 'bin')));
                         paramBC.rawFile = decompDataFile;
                         % Decompression
                         %                         success = pyrunfile("MTSDecomp_From_Matlab.py","success",datapath = strrep(fullfile(RawDataPaths(id).folder,RawDataPaths(id).name),'\','/'),...
                         %                             JsonPath =  strrep(fullfile(RawDataPaths(id).folder,strrep(RawDataPaths(id).name,'cbin','ch')),'\','/'), savepath = strrep(fullfile(Params.tmpdatafolder,strrep(RawDataPaths(id).name,'cbin','bin')),'\','/'));
                         %                         % Also copy metafile
-                        copyfile(strrep(fullfile(Params.RawDataPaths(id).folder,Params.RawDataPaths(id).name),'cbin','meta'),strrep(fullfile(Params.tmpdatafolder,Params.RawDataPaths(id).name),'cbin','meta'))
+                        copyfile(strrep(fullfile(Params.RawDataPaths(id).folder, Params.RawDataPaths(id).name), 'cbin', 'meta'), strrep(fullfile(Params.tmpdatafolder, Params.RawDataPaths(id).name), 'cbin', 'meta'))
                     end
-                    ephysap_tmp = fullfile(Params.tmpdatafolder,strrep(Params.RawDataPaths(id).name,'cbin','bin'));
+                    ephysap_tmp = fullfile(Params.tmpdatafolder, strrep(Params.RawDataPaths(id).name, 'cbin', 'bin'));
                     %                     DecompressionFlag = 1;
                 end
             end
@@ -104,16 +114,16 @@ if Params.UnitMatch
 
         %% Run UnitMatch
         GlobalUnitMatchClock = tic;
-        [UniqueIDConversion, MatchTable, WaveformInfo, UMparam] = UnitMatch(clusinfo,UMparam);
+        [UniqueIDConversion, MatchTable, WaveformInfo, UMparam] = UnitMatch(clusinfo, UMparam);
         UMrunTime = toc(GlobalUnitMatchClock);
-        save(fullfile(UMparam.SaveDir,'UnitMatch.mat'),'UniqueIDConversion','MatchTable','WaveformInfo','UMparam','UMrunTime')
-        DataSizeParam = CalculateDuration(Params.SaveDir);
-        disp(['UnitMatch took ' num2str(round(UMrunTime/60*10)/10) 'minutes to run'])
+        save(fullfile(UMparam.SaveDir, 'UnitMatch.mat'), 'UniqueIDConversion', 'MatchTable', 'WaveformInfo', 'UMparam', 'UMrunTime')
+        DataSizeParam = CalculateDuration(Params.SaveDir, ephys_dirs);
+        disp(['UnitMatch took ', num2str(round(UMrunTime/60*10)/10), ' minute(s) to run'])
 
     end
 elseif Params.DecompressionFlag % You might want to at least save out averaged waveforms for every session to get back to later, if they were saved out by bomcell
     % Extract average waveforms
-    ExtractAndSaveAverageWaveforms(clusinfo,UMparam)
+    ExtractAndSaveAverageWaveforms(clusinfo, UMparam)
 end
 
 return

--- a/Dependencies/UnitMatchPipeline/UnitMatch.m
+++ b/Dependencies/UnitMatchPipeline/UnitMatch.m
@@ -32,7 +32,7 @@ function  [UniqueIDConversion, MatchTable, WaveformInfo, param] = UnitMatch(clus
 
 %% Parameters - tested on these values, but feel free to try others
 Scores2Include = param.Scores2Include % Good to show for failure prevention
-TakeChannelRadius = 120; %in micron around max channel; 120 so far best tested
+TakeChannelRadius = 200; %in micron around max channel; 120 so far best tested
 maxdist = 100; % Maximum distance at which units are considered as potential matches %best tested so far 100
 param.removeoversplits = 0; % Remove oversplits based on ISI violations or not?
 param.MakeOwnNaiveBayes = 1; % if 0, use standard matlab version, which assumes normal distributions --> not recommended

--- a/MainAnalysis_Example.m
+++ b/MainAnalysis_Example.m
@@ -1,17 +1,17 @@
 %% User Input
 %% Path information
-DataDir = {'H:\MatchingUnits\RawData'}; % Raw data folders, typically servers were e.g. *.cbin files are stored
-SaveDir = 'H:\MatchingUnits\Output\' % Folder where to store the results
-tmpdatafolder = 'H:\MatchingUnits\Tmp'; % temporary folder for temporary decompression of data 
-KilosortDir = 'H:\MatchingUnits\KilosortOutput'; % Kilosort output folder
+DataDir = {'/home/netshare/zinu/'}; % Raw data folders, typically servers were e.g. *.cbin files are stored
+SaveDir = '/home/netshare/zinu/JF067/unitMatch' % Folder where to store the results
+tmpdatafolder = '/media/julie/ExtraHD/data_temp'; % temporary folder for temporary decompression of data 
+KilosortDir = '/home/netshare/zinu/'; % Kilosort output folder
 GithubDir = 'C:\Users\EnnyB\Documents\GitHub'; % Github directory
-PythonEXE = 'C:\Users\EnnyB\anaconda3\envs\pyks2\pythonw.exe' % Python version to run python code in:
+%PythonEXE = 'C:\Users\EnnyB\anaconda3\envs\pyks2\pythonw.exe' % Python version to run python code in:
 
 %% Information on experiments
-MiceOpt = {'AL032','AV008','CB016','EB019','JF067'}; % Add all mice you want to analyze
+MiceOpt = {'JF067'}; % Add all mice you want to analyze
 DataDir2Use = repmat(1,[1,length(MiceOpt)]); % In case you have multiple DataDir, index which directory is used for each mouse
 RecordingType = repmat({'Acute'},1,length(MiceOpt)); % And whether recordings were acute (default)
-RecordingType(ismember(MiceOpt,{'AL032','EB019','CB016','AV008','JF067'}))={'Chronic'}; %EB014', % Or maybe Chronic?
+RecordingType(ismember(MiceOpt,{'JF067'}))={'Chronic'}; %EB014', % Or maybe Chronic?
 
 %% Parameters on how to prepare units/data for analysis
 PrepareClusInfoparams.RunPyKSChronicStitched = 0; % Default 0. if 1, run PyKS chronic recordings stitched when same IMRO table was used
@@ -49,36 +49,36 @@ PrepareClusInfoparams.SaveDir = SaveDir; % Save results here
 PrepareClusInfoparams.tmpdatafolder = tmpdatafolder; % use this as a local directory (should be large enough to handle all sessions you want to combine)
 
 %% All dependencies you want to add (you may need to download these, all available via github)
-addpath(genpath(cd))
-
-% Required (for using UnitMatch):
-addpath(genpath(fullfile(GithubDir,'spikes')))% Should work with normal spikes toolbox, but I use the forked version in https://github.com/EnnyvanBeest/spikes
-addpath(genpath(fullfile(GithubDir,'npy-matlab'))) % https://github.com/kwikteam/npy-matlab
-addpath(genpath(fullfile(GithubDir,'mtscomp'))) % https://github.com/int-brain-lab/mtscomp
-
-% Advised (quality metrics for unit selection):
-addpath(genpath(fullfile(GithubDir,'bombcell'))) % DOI: 10.5281/zenodo.8172822, https://github.com/Julie-Fabre/bombcell 
-
-% Optional for histology:
-addpath(genpath(fullfile(GithubDir,'AP_histology'))) % https://github.com/petersaj/AP_histology
-addpath(genpath(fullfile(GithubDir,'allenCCF'))) % https://github.com/cortex-lab/allenCCF
-
-% UNITMATCH - Move to top of paths 
-addpath(genpath(fullfile(GithubDir,'UnitMatch'))) % Make sure to have this one fresh in the path (so run this last)
-
-try
-    % Python version to run python code in:
-    pyversion(PythonEXE) %Explanation on how to do this is provided in the README
-catch ME
-    disp(ME)
-end
+% addpath(genpath(cd))
+% 
+% % Required (for using UnitMatch):
+% addpath(genpath(fullfile(GithubDir,'spikes')))% Should work with normal spikes toolbox, but I use the forked version in https://github.com/EnnyvanBeest/spikes
+% addpath(genpath(fullfile(GithubDir,'npy-matlab'))) % https://github.com/kwikteam/npy-matlab
+% addpath(genpath(fullfile(GithubDir,'mtscomp'))) % https://github.com/int-brain-lab/mtscomp
+% 
+% % Advised (quality metrics for unit selection):
+% addpath(genpath(fullfile(GithubDir,'bombcell'))) % DOI: 10.5281/zenodo.8172822, https://github.com/Julie-Fabre/bombcell 
+% 
+% % Optional for histology:
+% addpath(genpath(fullfile(GithubDir,'AP_histology'))) % https://github.com/petersaj/AP_histology
+% addpath(genpath(fullfile(GithubDir,'allenCCF'))) % https://github.com/cortex-lab/allenCCF
+% 
+% % UNITMATCH - Move to top of paths 
+% addpath(genpath(fullfile(GithubDir,'UnitMatch'))) % Make sure to have this one fresh in the path (so run this last)
+% 
+% try
+%     % Python version to run python code in:
+%     pyversion(PythonEXE) %Explanation on how to do this is provided in the README
+% catch ME
+%     disp(ME)
+% end
 
 %% Actual pipeline
 %% PyKS - run pykilosort from Matlab/Python integration
-RunPyKS2_FromMatlab
+%RunPyKS2_FromMatlab
 
 %% Runs unitmatch across all data from a mouse to generate a table
 RunUnitMatchAllDataPerMouse
 
 %% Across Mice Graphs
-SummarizeAcrossMice
+%SummarizeAcrossMice

--- a/README.md
+++ b/README.md
@@ -22,12 +22,13 @@ Toolboxes that are useful for other parts of analysis pipeline (but not necessar
 - https://github.com/cortex-lab/allenCCF
 - https://github.com/EnnyvanBeest/GeneralNeuropixelAnalysisFunctions
 
-%% Usage %%
+### Usage
 
 The UnitMatch algorithm is called with the function RunUnitMatch.m, with kilosort output directories and parameters as input. 
-It is advised to initially follow MainAnalysis_Example.m to understand how UnitMatch can be used.  
+See the files `um_pipeline.m` (that calls`um_runUnitMatch.m`) or `RunUnitMatchAllDataPerMouse.m` for an example workflow. 
 
-%% Examples %%
+
+## Examples
 
 Two recording sessions of same IMRO table. In the first recording this unit was oversplit, and UnitMatch will Merge it. Additonally it found it's match in the second recording.
 

--- a/RunUnitMatchAllDataPerMouse.m
+++ b/RunUnitMatchAllDataPerMouse.m
@@ -2,7 +2,8 @@
 % Load all data
 % Find available datasets (always using dates as folders)
 clear DateOpt
-DateOpt = arrayfun(@(X) dir(fullfile(DataDir{DataDir2Use(X)},MiceOpt{X},'*-*')),1:length(MiceOpt),'UniformOutput',0);
+%dd = arrayfun(@(X) fullfile(DataDir{DataDir2Use(X)},MiceOpt{X},'*-*'),1:length(MiceOpt),'UniformOutput',0);
+DateOpt = arrayfun(@(X) dir(fullfile(DataDir{DataDir2Use(X)},MiceOpt{X},'*-*')),1:length(MiceOpt),'UniformOutput',0); % DataDir2Use = server 
 DateOpt = cellfun(@(X) X([X.isdir]),DateOpt,'UniformOutput',0);
 DateOpt = cellfun(@(X) {X.name},DateOpt,'UniformOutput',0);
 
@@ -47,7 +48,7 @@ for midx = 1:length(MiceOpt)
     end
     subsesopt(cellfun(@isempty,channelposition))=[];
     channelposition(cellfun(@isempty,channelposition))=[];
-    AllKiloSortPaths = subsesopt;
+    subsesoptAll = subsesopt;
     ImroCount = 1;
     IMROTableOpt = {};
     ChannelPosOpt = {};
@@ -77,13 +78,13 @@ for midx = 1:length(MiceOpt)
         continue
     end
     %% Prepare cluster information
-    PrepareClusInfoparams = PrepareClusInfo(AllKiloSortPaths,PrepareClusInfoparams);
+    PrepareClusInfoparams = PrepareClusInfo(subsesoptAll,PrepareClusInfoparams);
     PrepareClusInfoparams.RecType = RecordingType{midx};%
 
     %% Run UnitMatch
     UnitMatchExist = dir(fullfile(PrepareClusInfoparams.SaveDir,'**','UnitMatch.mat'));
     if isempty(UnitMatchExist) || PrepareClusInfoparams.RedoUnitMatch
-        UMparam = RunUnitMatch(AllKiloSortPaths,PrepareClusInfoparams);
+        UMparam = RunUnitMatch(subsesoptAll,PrepareClusInfoparams);
         
         %% Evaluate (within unit ID cross-validation)
         EvaluatingUnitMatch(UMparam.SaveDir);

--- a/um_pipeline.m
+++ b/um_pipeline.m
@@ -1,0 +1,45 @@
+%% ~~ Example unit match pipeline ~~
+% 1. Adjust the paths in the following sections:
+%         'Where to save data '
+%         'Information on mice and recording types'
+%         'get all raw ephys and kilosort directories'
+%         and the parameters in um_runUnitMatch
+%
+% 2. Run!
+%         This pipeline will:
+%           (1) load your ephys data, 
+%           (2) decompress your raw data if it is in .cbin format 
+%           (3) run quality metrics (bombcell) on your data and save the output
+%           (4) run unit match on your data and save the output
+%           (5) bring up summary plots and a GUI to flip through classified cells.
+%         The first time, this pipeline will be significantly slower (10-20' more)
+%         than after because it extracts raw waveforms. Subsequent times these
+%         pre-extracted waveforms are simply loaded in.
+%
+% 3. Check the output plots and output of `EvaluatingUnitMatch`. 
+%         You may want to adjust/fine-tune the following:
+%         - Which metrics are used in match. They are defined in PrepareClusInfoparams.Scores2Include. 
+%         You want to remove any metrics with low AUC and/or add any metrics with a high AUC
+%         - the prior used in the model (e.g. 'Acute' vs 'Chronic') 
+
+%% Where to save data - CHANGE THESE PATHS
+SaveDir = '/home/netshare/zinu/JF067/unitMatch'; % Folder where to store the results
+tmpdatafolder = '/media/julie/ExtraHD/data_temp'; % temporary folder for temporary decompression of data 
+
+%% Information on mice and recording types - CHANGE THESE MOUSE NAMES AND RECORDING TYPES
+MiceOpt = {'JF067'}; % Add all mice you want to analyze
+RecordingType(ismember(MiceOpt,{'JF067'}))={'Chronic'}; % 'Acute' or 'Chronic'
+
+for iMouse = 1:size(MiceOpt,2)
+
+    %% get all raw ephys and kilosort directories - CHANGE THESE PATHS
+    ephys_dirs = {path_to_all_ephys_dirs}; % this should be a cell array, with each cell containing the path to your raw .bin, .cbin or .dat data. 
+    kilosort_dirs = {path_to_all_kilosort_dirs}; % this should be a cell array, with each cell containing the path to your kilosort output files 
+    thisRecordingType = RecordingType{iMouse};
+    mouseName = MiceOpt{iMouse};
+
+    %% run unit match
+    [PrepareClusInfoparams, UMparam, UniqueIDConversion, MatchTable, WaveformInfo]  = um_runUnitMatch(kilosort_dirs, ephys_dirs, SaveDir, tmpdatafolder, thisRecordingType, mouseName);  
+
+    %% GUI: look at matches 
+end

--- a/um_runUnitMatch.m
+++ b/um_runUnitMatch.m
@@ -1,0 +1,124 @@
+
+
+function [PrepareClusInfoparams, UMparam, UniqueIDConversion, MatchTable, WaveformInfo] = um_runUnitMatch(kilosort_dirs, ephys_dirs, SaveDir, tmpdatafolder, thisRecordingType, mouseName)
+% Run unit match
+% ------
+% Inputs
+% ------
+% kilosort_dirs: cell array, with each cell containing the path to your raw .bin, .cbin or .dat data.
+% ephys_dirs: cell array, with each cell containing the path to your kilosort output files.
+% SaveDir: string, where to save unitmatch data
+% tmpdatafolder: string, where to store any temporary files (eg decompressed ephys files, ...)
+% thisRecordingType: string. either 'Chronic' or 'Acute'
+% mouseName: string
+% ------
+% Outputs
+% ------
+% PrepareClusInfoparams: strcuture containing the paramaters used 
+% UMparam: strcuture containing the paramaters used 
+% UniqueIDConversion: structure containing a summary unit match's results:
+%    - UniqueIDConversion.UniqueID returns, for each unit, the ID assigned
+%    to them. Any duplicate values indicates units that were matched
+%    - UniqueIDConversion.OriginalClusID is a 1 x number_of_units unit32 vector, gives each unit's original label
+%    - UniqueIDConversion.recsesAll is a 1 x number_of_units double vector, returns from which recording (1:number_of_recordings)
+%    each unit comes from 
+%    - UniqueIDConversion.GoodID is a 1 x number_of_units binary double
+%    vector, returns for each unit whether it was classified as good or
+%    not.
+% MatchTable: structure detailing unit match's results, with scores for
+% each metric used: 
+% ------
+%% Parameters and settings
+PrepareClusInfoparams.RunPyKSChronicStitched = 0; % Default 0. if 1, run PyKS chronic recordings stitched when same IMRO table was used
+PrepareClusInfoparams.CopyToTmpFirst = 1; % If 1, copy data to local first, don't run from server (= advised!)
+PrepareClusInfoparams.DecompressLocal = 1; % If 1, uncompress data first if it's currently compressed (= necessary for unitmatch and faster for QualityMetrics)
+PrepareClusInfoparams.deNoise = 0;
+PrepareClusInfoparams.nSavedChans = 385;
+PrepareClusInfoparams.nSyncChans = 1;
+% Storing preprocessed data?
+PrepareClusInfoparams.ReLoadAlways = 1; % If 1, SP & Clusinfo are always loaded from KS output
+PrepareClusInfoparams.saveSp = 1; % Save SP struct for easy loading of preprocessed data
+PrepareClusInfoparams.binsz = 0.01; %Bin size for PSTHs in seconds
+PrepareClusInfoparams.deNoise = 1; %whether to try and denoise data
+
+% Quality Metrics
+PrepareClusInfoparams.RunQualityMetrics = 1; % If 1, Run the quality metrics (Bombcell @JulieFabre)
+PrepareClusInfoparams.RedoQM = 0; %if 1, redo quality metrics if it already exists
+PrepareClusInfoparams.InspectQualityMetrics = 0; % If 1, Inspect the quality matrix/data set using the GUI (manual inspection)
+PrepareClusInfoparams.loadPCs = 0; % Only necessary when computiong isoluation metrics/drift in QM. You save a lot of time keeping this at 0
+
+% UnitMatch
+PrepareClusInfoparams.UnitMatch = 1; % If 1, find identical units across sessions or oversplits in a fast and flexible way
+PrepareClusInfoparams.RedoUnitMatch = 1; % if 1, Redo unitmatch
+PrepareClusInfoparams.separateIMRO = 0; % Run for every IMRO separately (for memory reasons or when having multiple probes this might be a good idea)
+
+% UnitMatch Parameters:
+% All parameters to choose from: {'AmplitudeSim','spatialdecaySim','WavformMSE','WVCorr','CentroidDist','CentroidVar','CentroidDistRecentered','TrajAngleSim','TrajDistSim'};
+% WavformSim is average of WVCorr and WavformMSE
+% CentroidOverlord is average of CentroidDistRecentered and CentroidVar
+PrepareClusInfoparams.Scores2Include = {'CentroidDist', 'WavformSim', 'CentroidOverlord', 'spatialdecaySim', 'AmplitudeSim', 'TrajAngleSim'}; %{'AmplitudeSim','spatialdecayfitSim','WavformSim','CentroidDist','CentroidVar','TrajAngleSim'}; %
+PrepareClusInfoparams.ApplyExistingBayesModel = 0; %If 1, use probability distributions made available by us -
+PrepareClusInfoparams.MakePlotsOfPairs = 0; % Plots pairs for inspection (UnitMatch)
+PrepareClusInfoparams.AssignUniqueID = 1; % Assign UniqueID
+PrepareClusInfoparams.GoodUnitsOnly = 1; % Include only good untis in the UnitMatch analysis - faster and more sensical
+PrepareClusInfoparams.extractSync = 0;
+PrepareClusInfoparams.plot = 0;
+
+PrepareClusInfoparams.SaveDir = SaveDir; % Save results here
+PrepareClusInfoparams.tmpdatafolder = tmpdatafolder; % use this as a local directory (should be large enough to handle all sessions you want to combine)
+
+%% Loading data from kilosort/phy
+subsesopt = kilosort_dirs;
+
+if strcmp(thisRecordingType, 'Chronic')
+    if ~PrepareClusInfoparams.RunPyKSChronicStitched %MatchUnitsAcrossDays
+        disp('Unit matching in Matlab')
+        subsesopt(cell2mat(cellfun(@(X) any(strfind(X, 'Chronic')), subsesopt, 'UniformOutput', 0))) = []; %Use separate days and match units via matlab script
+    else
+        disp('Using chronic pyks option')
+        subsesopt = subsesopt(cell2mat(cellfun(@(X) any(strfind(X, 'Chronic')), subsesopt, 'UniformOutput', 0))); %Use chronic output from pyks
+    end
+end
+
+
+%Create saving directories
+clear params
+thisIMRO = '';
+thisdate = [];
+if ~exist(fullfile(SaveDir))
+    mkdir(fullfile(SaveDir))
+end
+PrepareClusInfoparams.SaveDir = fullfile(SaveDir);
+if isempty(subsesopt)
+    disp(['No data found for ', mouseName])
+
+end
+
+%% Pre-process: quality metrics
+PrepareClusInfoparams = PrepareClusInfo(subsesopt, PrepareClusInfoparams, ephys_dirs);
+
+%% Run unit match
+[UMparam, UniqueIDConversion, MatchTable, WaveformInfo] = RunUnitMatch(subsesopt, PrepareClusInfoparams, ephys_dirs);
+
+%% Output plots
+if PrepareClusInfoparams.plot
+    % Evaluate (within unit ID cross-validation)
+    EvaluatingUnitMatch(UMparam.SaveDir);
+
+    % Function analysis
+    ComputeFunctionalScores(UMparam.SaveDir)
+end
+% Figures
+if UMparam.MakePlotsOfPairs
+    DrawBlind = 0; %1 for blind drawing (for manual judging of pairs)
+    DrawPairsUnitMatch(UMparam.SaveDir, DrawBlind);
+end
+
+% Quality metrics
+try
+    QualityMetricsROCs(UMparam.SaveDir);
+catch ME
+    disp(['Couldn''t do Quality metrics for ', mouseName])
+end
+
+end


### PR DESCRIPTION
Hi Enny,

I added:

a unit match wrapper script (um_runUnitMatch.m)
an example pipeline script (um_pipeline.m)
with some documentation. It should hopefully help anyone get started!
I made a few modifications to also allow users to input ephys and kilosort paths as a cell array of strings. I think this way it's easy to use & for instance subselect days you want to match.
I also have to make some modifications to accommodate for Kilosort2's output (no cluster_groups.tsv and the channel_map doesn't include all channels).
I additionally had to change the input waveformTemplates to bombcell (for it to include any "empty" clusters), otherwise it wasn't the right size and would crash. And then I have to reindex and only keep the non-empty clusters. 