### PR TITLE
bugfix test_matches_per_shank()

### DIFF
--- a/UnitMatchPy/UnitMatchPy/metric_functions.py
+++ b/UnitMatchPy/UnitMatchPy/metric_functions.py
@@ -706,11 +706,11 @@ def test_matches_per_shank(pairs, avg_centroid, sid, param):
             correct_shank_b = np.logical_and(centroid_b[1,:] < max_dist,  centroid_b[1,:] > min_dist)
 
             if np.all(correct_shank_a == correct_shank_b) != True:
-                print(f'These pairs may be bad {np.argwhere(correct_shank_a != correct_shank_b)}')
-                #delete pairs which are one different shanks
-                bad_idxs = np.argwhere(correct_shank_a != correct_shank_b)
-                correct_shank_a = np.delete(correct_shank_a, bad_idxs)
-                correct_shank_b = np.delete(correct_shank_b, bad_idxs)
+                #delete pairs which are on different shanks
+                bad_idx = np.argwhere(correct_shank_a != correct_shank_b)[0]
+                print(f'These pairs may be bad {bad_idx}, so are excluded from drift correction')
+                correct_shank_a[bad_idx]=False
+                correct_shank_b[bad_idx]=False
                 
             shank_id_tmp[correct_shank_a] = i
 


### PR DESCRIPTION
Hiya!

Suggesting a small patch after I ran into an error with Neuropixel 2.0 data recorded on multiple shanks:

I already made sure to pull the most recent version of UnitMatchPy with

 `pip install UnitMatchPy --upgrade` (and adding a comment on line 715)

![image](https://github.com/user-attachments/assets/a8b443c9-3b8d-48e5-af6e-175565354625)

"boolean index did not match indexed array along dimension 0'"

This occurs when a bad match is identified and deleting the index leads to failed indexing in shank_id_tmp, which has a different size or 'index along dimension 0' .

Suggesting a change here which worked for our data, simply setting the correct_shank values to False, making sure they will not be counted as a match on the shank.

All the best,
Charles