### PR TITLE
Memory-efficient chunked pairwise metric computation

### DIFF
--- a/UnitMatchPy/UnitMatchPy/default_params.py
+++ b/UnitMatchPy/UnitMatchPy/default_params.py
@@ -27,6 +27,7 @@ def get_default_param(param = None):
             'units_per_shank_thrs' : 15, # threshold for doing per shank drift correction
             'match_threshold' : 0.5, # probability threshold to consider as a match
             'curve_fit_maxfev' : 10000, # max evaluations for decay curve fitting
+            'chunk_size' : 500, # row-chunk size for pairwise metric computation
         }
     
     tmp['score_vector'] = np.arange(tmp['stepsz']/2 ,1 ,tmp['stepsz'])

--- a/UnitMatchPy/UnitMatchPy/metric_functions.py
+++ b/UnitMatchPy/UnitMatchPy/metric_functions.py
@@ -252,6 +252,155 @@ def centroid_metrics(euclid_dist, param):
 
     return centroid_dist, centroid_var
 
+def get_euclidean_metrics_chunked(avg_waveform_per_tp_flip, param):
+    """
+    Memory-efficient computation of Euclidean centroid metrics.
+
+    Fuses get_Euclidean_dist + centroid_metrics + peak-slice reduction into a single
+    pass that processes units in row-chunks, avoiding the full (N, waveidx, flips, N)
+    intermediate array. Produces identical results to the original three-step pipeline.
+
+    Parameters
+    ----------
+    avg_waveform_per_tp_flip : ndarray (3, n_units, spike_width, 2, n_flips)
+        The average waveform per time point with the x axis flipped and not flipped
+    param : dict
+        The param dictionary. Uses 'chunk_size' (default 500) to control the
+        number of rows processed per iteration.
+
+    Returns
+    -------
+    centroid_dist : ndarray (n_units, n_units)
+        Rescaled centroid distance score at peak timepoint
+    centroid_var : ndarray (n_units, n_units)
+        Rescaled centroid variance score across timepoints
+    euclid_dist : ndarray (n_units, n_units)
+        Raw (unscaled) Euclidean distance at peak timepoint, minimized over flips.
+        Used downstream for distance-based pair filtering.
+    """
+    waveidx = param['waveidx']
+    n_units = param['n_units']
+    max_dist = param['max_dist']
+    chunk_size = max(1, param.get('chunk_size', 500))
+
+    waveidx_arr = np.asarray(waveidx)
+    peak_loc = int(param['peak_loc'])
+    peak_matches = np.flatnonzero(waveidx_arr == peak_loc)
+    if peak_matches.size == 0:
+        raise ValueError("param['peak_loc'] must be present in param['waveidx'].")
+    peak_idx = int(peak_matches[0])
+
+    n_waveidx = len(waveidx)
+    ddof = 1 if n_waveidx > 1 else 0
+
+    # Extract relevant slices: (3, N, len_waveidx, n_flips)
+    data_cv0 = avg_waveform_per_tp_flip[:, :, waveidx, 0, :]
+    data_cv1 = avg_waveform_per_tp_flip[:, :, waveidx, 1, :]
+
+    # Preallocate (N, N) outputs
+    raw_centroid_dist = np.full((n_units, n_units), np.nan)
+    raw_centroid_var = np.full((n_units, n_units), np.nan)
+
+    for i_start in range(0, n_units, chunk_size):
+        i_end = min(i_start + chunk_size, n_units)
+        # (3, chunk, 1, waveidx, flips) - (3, 1, N, waveidx, flips) = (3, chunk, N, waveidx, flips)
+        diff = (data_cv0[:, i_start:i_end, np.newaxis, :, :]
+                - data_cv1[:, np.newaxis, :, :, :])
+        # Euclidean norm over spatial dims -> (chunk, N, waveidx, flips)
+        ed = np.linalg.norm(diff, axis=0)
+        del diff
+
+        # centroid_dist: distance at peak, min over flips
+        raw_centroid_dist[i_start:i_end, :] = np.nanmin(ed[:, :, peak_idx, :], axis=-1)
+
+        # centroid_var: variance over waveidx, min over flips
+        raw_centroid_var[i_start:i_end, :] = np.nanmin(
+            np.nanvar(ed, axis=2, ddof=ddof), axis=-1)
+        del ed
+
+    # euclid_dist is the raw centroid distance (before rescaling)
+    euclid_dist = raw_centroid_dist.copy()
+
+    # Rescale centroid_dist using max_dist (same as centroid_metrics)
+    min_cd = np.nanmin(raw_centroid_dist)
+    denom = max_dist - min_cd
+    if not np.isfinite(denom) or denom <= 0:
+        centroid_dist = np.zeros_like(raw_centroid_dist)
+    else:
+        centroid_dist = 1 - ((raw_centroid_dist - min_cd) / denom)
+        centroid_dist = np.clip(centroid_dist, 0, 1)
+    centroid_dist[np.isnan(centroid_dist)] = 0
+
+    # Rescale centroid_var (same as centroid_metrics)
+    centroid_var = np.sqrt(raw_centroid_var)
+    centroid_var = re_scale(centroid_var)
+    centroid_var[np.isnan(centroid_var)] = 0
+
+    return centroid_dist, centroid_var, euclid_dist
+
+def get_recentered_metrics_chunked(avg_waveform_per_tp_flip, avg_centroid, param):
+    """
+    Memory-efficient computation of recentered centroid distance metric.
+
+    Fuses get_recentered_euclidean_dist + recentered_metrics into a single pass.
+    First subtracts each unit's average centroid position from its per-timepoint
+    waveform trajectory, then computes pairwise Euclidean distances in row-chunks
+    to avoid the full (N, waveidx, flips, N) intermediate array.
+
+    Parameters
+    ----------
+    avg_waveform_per_tp_flip : ndarray (3, n_units, spike_width, 2, n_flips)
+        The average waveform per time point with the x axis flipped and not flipped
+    avg_centroid : ndarray (3, n_units, 2)
+        The average spatial location for each unit, subtracted before distance
+        computation to isolate trajectory shape from absolute position.
+    param : dict
+        The param dictionary. Uses 'chunk_size' (default 500) to control the
+        number of rows processed per iteration.
+
+    Returns
+    -------
+    centroid_dist_recentered : ndarray (n_units, n_units)
+        Rescaled recentered centroid distance score
+    """
+    waveidx = param['waveidx']
+    n_units = param['n_units']
+    spike_width = param['spike_width']
+    chunk_size = max(1, param.get('chunk_size', 500))
+
+    # Recenter: subtract avg_centroid from each timepoint (per-unit, no N×N)
+    avg_centroid_broadcast = np.tile(
+        np.expand_dims(avg_centroid, axis=(3, 4)), (1, 1, 1, spike_width, 2))
+    recentered = np.swapaxes(
+        np.swapaxes(avg_waveform_per_tp_flip, 2, 3) - avg_centroid_broadcast, 2, 3)
+    del avg_centroid_broadcast
+
+    # Extract CV halves at waveidx: (3, N, len_waveidx, n_flips)
+    rc_cv0 = recentered[:, :, waveidx, 0, :]
+    rc_cv1 = recentered[:, :, waveidx, 1, :]
+    del recentered
+
+    raw_result = np.full((n_units, n_units), np.nan)
+
+    for i_start in range(0, n_units, chunk_size):
+        i_end = min(i_start + chunk_size, n_units)
+        # (3, chunk, 1, waveidx, flips) - (3, 1, N, waveidx, flips) = (3, chunk, N, waveidx, flips)
+        diff = (rc_cv0[:, i_start:i_end, np.newaxis, :, :]
+                - rc_cv1[:, np.newaxis, :, :, :])
+        # Euclidean norm over spatial dims -> (chunk, N, waveidx, flips)
+        ed = np.linalg.norm(diff, axis=0)
+        del diff
+
+        # recentered_metrics: mean over waveidx, then min over flips
+        raw_result[i_start:i_end, :] = np.nanmin(
+            np.nanmean(ed, axis=2), axis=-1)
+        del ed
+
+    centroid_dist_recentered = re_scale(raw_result)
+    centroid_dist_recentered[np.isnan(centroid_dist_recentered)] = 0
+
+    return centroid_dist_recentered
+
 def get_recentered_euclidean_dist(avg_waveform_per_tp_flip, avg_centroid, param):
     """
     Find a Euclidean distance where the location per time has been centered around the average position

--- a/UnitMatchPy/UnitMatchPy/overlord.py
+++ b/UnitMatchPy/UnitMatchPy/overlord.py
@@ -83,18 +83,14 @@ def extract_metric_scores(extracted_wave_properties, session_switch, within_sess
     #effected by drift
     for i in range(niter):
         avg_waveform_per_tp_flip = mf.flip_dim(avg_waveform_per_tp, param)
-        euclid_dist = mf.get_Euclidean_dist(avg_waveform_per_tp_flip, param)
 
-        centroid_dist, centroid_var = mf.centroid_metrics(euclid_dist, param)
+        centroid_dist, centroid_var, euclid_dist = mf.get_euclidean_metrics_chunked(
+            avg_waveform_per_tp_flip, param)
 
-        euclid_dist_rc = mf.get_recentered_euclidean_dist(avg_waveform_per_tp_flip, avg_centroid, param)
+        centroid_dist_recentered = mf.get_recentered_metrics_chunked(
+            avg_waveform_per_tp_flip, avg_centroid, param)
 
-        centroid_dist_recentered = mf.recentered_metrics(euclid_dist_rc)
         traj_angle_score, traj_dist_score = mf.dist_angle(avg_waveform_per_tp_flip, param)
-
-
-        # Average Euc Dist
-        euclid_dist = np.nanmin(euclid_dist[:,param['peak_loc'] - param['waveidx'] == 0, :,:].squeeze(), axis = 1 )
 
         # TotalScore
         include_these_pairs = np.argwhere( euclid_dist < param['max_dist']) #array indices of pairs to include

--- a/UnitMatchPy/tests/test_chunked_metrics.py
+++ b/UnitMatchPy/tests/test_chunked_metrics.py
@@ -1,0 +1,91 @@
+"""
+Tests that chunked metric functions produce identical results to the original
+non-chunked implementations.
+"""
+import numpy as np
+import pytest
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+import UnitMatchPy.metric_functions as mf
+import UnitMatchPy.default_params as default_params
+
+
+def _make_test_data(n_units=50, spike_width=82, n_flips=2, seed=42):
+    """Create synthetic avg_waveform_per_tp_flip and avg_centroid for testing."""
+    rng = np.random.RandomState(seed)
+    avg_waveform_per_tp_flip = rng.randn(3, n_units, spike_width, 2, n_flips)
+    # Sprinkle some NaNs to test NaN handling
+    nan_mask = rng.rand(3, n_units, spike_width, 2, n_flips) < 0.02
+    avg_waveform_per_tp_flip[nan_mask] = np.nan
+    avg_centroid = rng.randn(3, n_units, 2)
+    param = default_params.get_default_param()
+    param['n_units'] = n_units
+    param['spike_width'] = spike_width
+    param['n_channels'] = 384
+    return avg_waveform_per_tp_flip, avg_centroid, param
+
+
+def test_euclidean_metrics_match():
+    """Chunked euclidean metrics must match the original three-step pipeline."""
+    avg_wf_flip, _, param = _make_test_data()
+
+    # Original pipeline
+    euclid_dist_orig = mf.get_Euclidean_dist(avg_wf_flip, param)
+    centroid_dist_orig, centroid_var_orig = mf.centroid_metrics(euclid_dist_orig, param)
+    euclid_squeezed_orig = np.nanmin(
+        euclid_dist_orig[:, param['peak_loc'] - param['waveidx'] == 0, :, :].squeeze(),
+        axis=1)
+
+    # Chunked pipeline (use small chunk to exercise multiple iterations)
+    param['chunk_size'] = 17
+    centroid_dist_new, centroid_var_new, euclid_squeezed_new = \
+        mf.get_euclidean_metrics_chunked(avg_wf_flip, param)
+
+    np.testing.assert_allclose(euclid_squeezed_new, euclid_squeezed_orig,
+                               rtol=1e-10, equal_nan=True)
+    np.testing.assert_allclose(centroid_dist_new, centroid_dist_orig,
+                               rtol=1e-10, equal_nan=True)
+    np.testing.assert_allclose(centroid_var_new, centroid_var_orig,
+                               rtol=1e-10, equal_nan=True)
+
+
+def test_recentered_metrics_match():
+    """Chunked recentered metrics must match the original two-step pipeline."""
+    avg_wf_flip, avg_centroid, param = _make_test_data()
+
+    # Original pipeline
+    euclid_dist_rc = mf.get_recentered_euclidean_dist(avg_wf_flip, avg_centroid, param)
+    centroid_rc_orig = mf.recentered_metrics(euclid_dist_rc)
+
+    # Chunked pipeline
+    param['chunk_size'] = 17
+    centroid_rc_new = mf.get_recentered_metrics_chunked(avg_wf_flip, avg_centroid, param)
+
+    np.testing.assert_allclose(centroid_rc_new, centroid_rc_orig,
+                               rtol=1e-10, equal_nan=True)
+
+
+def test_chunk_size_edge_cases():
+    """Chunked functions work with chunk_size larger than n_units and chunk_size=1."""
+    avg_wf_flip, avg_centroid, param = _make_test_data(n_units=10)
+
+    # chunk_size > n_units (single chunk)
+    param['chunk_size'] = 9999
+    cd1, cv1, ed1 = mf.get_euclidean_metrics_chunked(avg_wf_flip, param)
+    rc1 = mf.get_recentered_metrics_chunked(avg_wf_flip, avg_centroid, param)
+
+    # chunk_size = 1 (one unit per chunk)
+    param['chunk_size'] = 1
+    cd2, cv2, ed2 = mf.get_euclidean_metrics_chunked(avg_wf_flip, param)
+    rc2 = mf.get_recentered_metrics_chunked(avg_wf_flip, avg_centroid, param)
+
+    np.testing.assert_allclose(cd1, cd2, rtol=1e-10, equal_nan=True)
+    np.testing.assert_allclose(cv1, cv2, rtol=1e-10, equal_nan=True)
+    np.testing.assert_allclose(ed1, ed2, rtol=1e-10, equal_nan=True)
+    np.testing.assert_allclose(rc1, rc2, rtol=1e-10, equal_nan=True)
+
+
+if __name__ == '__main__':
+    pytest.main([__file__, '-v'])


### PR DESCRIPTION
## Summary

The pairwise metric functions in `metric_functions.py` (`get_Euclidean_dist`, `get_recentered_euclidean_dist`) materialize full `(N, waveidx, flips, N)` intermediate arrays via `np.tile`. For large unit counts (N > 5,000), these arrays consume hundreds of GB. For example, N=14,000 units requires ~500 GB just for the tiled intermediates in `get_recentered_euclidean_dist`, making the pipeline impractical for large-scale Neuropixels recordings with many sessions.

This PR adds two **chunked** functions that fuse the producer and consumer steps (`get_Euclidean_dist` + `centroid_metrics` and `get_recentered_euclidean_dist` + `recentered_metrics`) and process units in configurable row-blocks. The chunked functions never materialize the full 4D intermediate, only a `(3, chunk_size, N, waveidx, flips)` working array per iteration.

### Changes

- **`metric_functions.py`**: Add `get_euclidean_metrics_chunked()` and `get_recentered_metrics_chunked()`
- **`overlord.py`**: Use chunked functions in `extract_metric_scores()`
- **`default_params.py`**: Add `chunk_size` parameter (default 500)
- **`tests/test_chunked_metrics.py`**: Tests confirming numerical equivalence between old and new code paths

Original functions are preserved for backward compatibility.

### Benchmark

Tested on a probe with **7,439 units across 26 sessions** (same data, same hardware):

| | Before | After | Improvement |
|---|---|---|---|
| Peak memory (MaxRSS) | 321 GB | 89 GB | **3.6x** |
| Total runtime | 1h 40m | 27m | **3.7x** |
| Self-match rate | 0.8330 | 0.8330 | Identical |

Additionally, probes with 11,000 to 14,000 units that previously OOM'd at 768 GB now complete at 300 to 400 GB.

### How it works

Both functions follow the same pattern:

1. Extract CV0 and CV1 data at `waveidx` timepoints: shape `(3, N, len_waveidx, n_flips)`
2. Loop over row-chunks of CV0 (default chunk_size=500):
   - Broadcast `(3, chunk, 1, waveidx, flips) - (3, 1, N, waveidx, flips)` to `(3, chunk, N, waveidx, flips)`
   - Compute Euclidean norm over spatial dims: `(chunk, N, waveidx, flips)`
   - Reduce to the needed metric (peak distance, variance, mean) and write into `(N, N)` output
   - Delete intermediates before next iteration
3. Apply the same rescaling as the original functions

The `chunk_size` parameter is tunable via `param['chunk_size']` and defaults to 500 (backward compatible via `param.get()`).

## Test plan

- [x] `test_euclidean_metrics_match`: Chunked output matches original 3-step pipeline (`np.allclose`, `rtol=1e-10`)
- [x] `test_recentered_metrics_match`: Chunked output matches original 2-step pipeline
- [x] `test_chunk_size_edge_cases`: Consistent results with `chunk_size=1` vs `chunk_size=9999`